### PR TITLE
added color palette selection and nice default color scheme

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -29,6 +29,7 @@ defaults = {
     'n_jobs': 1,
     'n_estimators': 100,
     'estimator_r': 'RandomForestClassifier',
+    'palette': 'Default'
 }
 
 
@@ -41,7 +42,8 @@ def classify_samples(output_dir: str, table: pd.DataFrame,
                      n_estimators: int=defaults['n_estimators'],
                      estimator: str=defaults['estimator_r'],
                      optimize_feature_selection: bool=False,
-                     parameter_tuning: bool=False) -> None:
+                     parameter_tuning: bool=False,
+                     palette: str=defaults['palette']) -> None:
 
     # extract category name from MetadataCategory
     category = metadata.to_series().name
@@ -60,7 +62,7 @@ def classify_samples(output_dir: str, table: pd.DataFrame,
         test_size=test_size, step=step, cv=cv, random_state=random_state,
         n_jobs=n_jobs, optimize_feature_selection=optimize_feature_selection,
         parameter_tuning=parameter_tuning, param_dist=param_dist,
-        calc_feature_importance=calc_feature_importance)
+        calc_feature_importance=calc_feature_importance, palette=palette)
 
     _visualize(output_dir, estimator, cm, accuracy, importances,
                optimize_feature_selection)

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -216,13 +216,21 @@ plugin.visualizers.register_function(
         'estimator': Str % Choices(
             ['RandomForestClassifier', 'ExtraTreesClassifier',
              'GradientBoostingClassifier', 'AdaBoostClassifier',
-             'KNeighborsClassifier', 'LinearSVC', 'SVC'])},
+             'KNeighborsClassifier', 'LinearSVC', 'SVC']),
+        'palette': Str % Choices(
+            ['Default', 'Greys', 'Purples', 'Blues', 'Greens', 'Oranges',
+             'Reds', 'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
+             'GnBu', 'PuBu', 'YlGn', 'bone_r', 'pink_r', 'summer_r', 'cool',
+             'hot_r', 'copper_r', 'gist_earth_r', 'terrain_r', 'gnuplot2_r',
+             'cubehelix_r', 'jet_r', 'viridis_r', 'plasma_r', 'inferno_r',
+             'magma_r'])},
     input_descriptions=input_descriptions,
     parameter_descriptions={
         **parameter_descriptions['base'],
         **parameter_descriptions['standard'],
         **parameter_descriptions['standard_metadata'],
-        **parameter_descriptions['estimator']},
+        **parameter_descriptions['estimator'],
+        'palette': 'The color palette to use for plotting.'},
     name='Supervised learning classifier.',
     description=description.format(
         'categorical', 'supervised learning classifier')

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -231,7 +231,7 @@ def split_optimize_classify(features, targets, category, estimator,
                             parameter_tuning=False, param_dist=None,
                             calc_feature_importance=False, load_data=True,
                             scoring=accuracy_score, classification=True,
-                            stratify=True):
+                            stratify=True, palette='Default'):
     # Load, stratify, and split training/test data
     X_train, X_test, y_train, y_test = _prepare_training_data(
         features, targets, category, test_size, random_state,
@@ -256,7 +256,7 @@ def split_optimize_classify(features, targets, category, estimator,
     # Predict test set values and plot data, as appropriate for estimator type
     predictions, predict_plot = _predict_and_plot(
         output_dir, y_test, y_pred, estimator, accuracy,
-        classification=classification)
+        classification=classification, palette=palette)
 
     # calculate feature importances, if appropriate for the estimator
     if calc_feature_importance:
@@ -319,10 +319,11 @@ def _calculate_feature_importances(X_train, estimator):
 
 
 def _predict_and_plot(output_dir, y_test, y_pred, estimator, accuracy,
-                      classification=True):
+                      classification=True, palette='Default'):
     if classification:
         predictions, predict_plot = _plot_confusion_matrix(
-            y_test, y_pred, sorted(estimator.classes_), accuracy)
+            y_test, y_pred, sorted(estimator.classes_), accuracy,
+            palette=palette)
     else:
         predictions = _linear_regress(y_test, y_pred)
         predict_plot = _regplot_from_dataframe(y_test, y_pred)

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -148,13 +148,17 @@ def _linear_regress(actual, pred):
                         index=[actual.name])
 
 
-def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True):
+def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True,
+                           palette='Default'):
+    if palette == 'Default':
+        palette = sns.cubehelix_palette(dark=0.15, light=0.95, as_cmap=True)
+
     cm = confusion_matrix(y_test, y_pred)
     # normalize
     if normalize:
         cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
 
-    confusion = sns.heatmap(cm)
+    confusion = sns.heatmap(cm, cmap=palette)
     plt.ylabel('True label')
     plt.xlabel('Predicted label')
     confusion.set_xticklabels(classes, rotation=90, ha='center')


### PR DESCRIPTION
the default is nice and soft... but many of the matplotlib defaults don't look great for this. I added a number of choices for palettes that seem okay, but it may make more sense at some point to define custom seaborn color palettes (how about this: each member of the qiime2 dev team gets to define their own color palette and then we can have "Greg's theme", etc)

The issue is that the confusion matrices tend to include mostly zero values and a handful of values close to 1 (ideally), with few intermediate values. For many [default colormaps](https://matplotlib.org/examples/color/colormaps_reference.html), this yields a bold color on a (nearly) white background, which is a bit hard on the eyes.

fixes #43 