### PR TITLE
fixed yticklabel horizontal alignment

### DIFF
--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -159,7 +159,7 @@ def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True):
     plt.xlabel('Predicted label')
     confusion.set_xticklabels(classes, rotation=90, ha='center')
     confusion.set_yticklabels(
-        sorted(classes, reverse=True), rotation=0, ha='center')
+        sorted(classes, reverse=True), rotation=0, ha='right')
 
     # generate confusion matrix as pd.DataFrame for viewing
     predictions = pd.DataFrame(cm, index=classes, columns=classes)


### PR DESCRIPTION
that was easy.

The yticklabels are now right-aligned, as shown below (the nonsensical labels were added in for the sake of ensuring that this worked with very long labels):

![image](https://user-images.githubusercontent.com/1907564/28992095-31a4de8a-7959-11e7-8590-c9eb271d8356.png)

fixes #44 