### PR TITLE
baseline error, ratio, and description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All machine-learning models implemented in q2-sample-classifier support the opti
 
 ![Alt text](./examples/rfe_plot.jpg?raw=true "Recursive feature elimination plot")
 ## Classification
-In a classification problem, we are interested in predicting the class labels for a number of unlabeled samples. The visualizers show overall accuracy scores (e.g., the percentage of times that the true class label is predicted), baseline error (the error rate for a classifier than always guesses the most common class), and error ratio (the n-fold improvement of the trained classifier over baseline error, or ER = baseline error / (1 - accuracy)). It also generates confusion matrices, showing how frequently samples belonging to each class are predicted to be the true class or another class. For example, the following depicts how frequently grape samples are classified to the correct Vineyard (94.1% of the time!):
+In a classification problem, we are interested in predicting the class labels for a number of unlabeled samples. The visualizers show overall accuracy scores (e.g., the percentage of times that the true class label is predicted), baseline accuracy (the accuracy rate for a classifier than always guesses the most common class), and accuracy ratio (the n-fold improvement of the trained classifier over baseline accuracy). It also generates confusion matrices, showing how frequently samples belonging to each class are predicted to be the true class or another class. For example, the following depicts how frequently grape samples are classified to the correct Vineyard (94.1% of the time!):
 
 ![Alt text](./examples/classify-kneighbors-vineyard.jpg?raw=true "classify k-neighbors Vineyard")
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All machine-learning models implemented in q2-sample-classifier support the opti
 
 ![Alt text](./examples/rfe_plot.jpg?raw=true "Recursive feature elimination plot")
 ## Classification
-In a classification problem, we are interested in predicting the class labels for a number of unlabeled samples. The visualizers show overall accuracy scores (e.g., the percentage of times that the true class label is predicted), and also generates confusion matrices, showing how frequently samples belonging to each class are predicted to be the true class or another class. For example, the following depicts how frequently grape samples are classified to the correct Vineyard (94.1% of the time!):
+In a classification problem, we are interested in predicting the class labels for a number of unlabeled samples. The visualizers show overall accuracy scores (e.g., the percentage of times that the true class label is predicted), baseline error (the error rate for a classifier than always guesses the most common class), and error ratio (the n-fold improvement of the trained classifier over baseline error, or ER = baseline error / (1 - accuracy)). It also generates confusion matrices, showing how frequently samples belonging to each class are predicted to be the true class or another class. For example, the following depicts how frequently grape samples are classified to the correct Vineyard (94.1% of the time!):
 
 ![Alt text](./examples/classify-kneighbors-vineyard.jpg?raw=true "classify k-neighbors Vineyard")
 

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -13,7 +13,8 @@ from os.path import join
 from warnings import filterwarnings
 from sklearn.exceptions import ConvergenceWarning
 from q2_sample_classifier.visuals import (
-    _two_way_anova, _pairwise_stats, _linear_regress)
+    _two_way_anova, _pairwise_stats, _linear_regress,
+    _calculate_baseline_accuracy)
 from q2_sample_classifier.classify import (
     classify_samples, regress_samples,
     maturity_index, detect_outliers, predict_coordinates)
@@ -65,6 +66,14 @@ class VisualsTests(SampleClassifierTestPluginBase):
         self.assertAlmostEqual(res.iloc[0]['Mean squared error'], 1.9413916666)
         self.assertAlmostEqual(res.iloc[0]['R'], 0.86414956372460128)
         self.assertAlmostEqual(res.iloc[0]['P-value'], 0.00028880275858705694)
+
+    def test_calculate_baseline_accuracy(self):
+        accuracy = 0.9
+        y_test = pd.Series(['a', 'a', 'a', 'b', 'b', 'b'], name="class")
+        classifier_accuracy = _calculate_baseline_accuracy(y_test, accuracy)
+        expected_results = (6, 3, 0.5, 1.8)
+        for i in zip(classifier_accuracy, expected_results):
+            self.assertEqual(i[0], i[1])
 
 
 class EstimatorsTests(SampleClassifierTestPluginBase):

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -170,19 +170,25 @@ def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True,
     # add empty row/column to show overall accuracy in bottom right cell
     # baseline error = error rate for a classifier that always guesses the
     # most common class
-    n_samples = len(y_test)
-    n_samples_largest_class = y_test.value_counts().iloc[0]
-    basline_error = 1 - n_samples_largest_class / n_samples
-    error_ratio = basline_error / (1 - accuracy)
+    n_samples, n_samples_largest_class, basline_accuracy, accuracy_ratio = \
+        _calculate_baseline_accuracy(y_test, accuracy)
     predictions["Overall Accuracy"] = ""
     predictions.loc["Overall Accuracy"] = ""
-    predictions.loc["Baseline Error"] = ""
+    predictions.loc["Baseline Accuracy"] = ""
     predictions.loc["Accuracy Ratio"] = ""
     predictions.loc["Overall Accuracy"]["Overall Accuracy"] = accuracy
-    predictions.loc["Baseline Error"]["Overall Accuracy"] = basline_error
-    predictions.loc["Accuracy Ratio"]["Overall Accuracy"] = error_ratio
+    predictions.loc["Baseline Accuracy"]["Overall Accuracy"] = basline_accuracy
+    predictions.loc["Accuracy Ratio"]["Overall Accuracy"] = accuracy_ratio
 
     return predictions, confusion
+
+
+def _calculate_baseline_accuracy(y_test, accuracy):
+    n_samples = len(y_test)
+    n_samples_largest_class = y_test.value_counts().iloc[0]
+    basline_accuracy = n_samples_largest_class / n_samples
+    accuracy_ratio = accuracy / basline_accuracy
+    return n_samples, n_samples_largest_class, basline_accuracy, accuracy_ratio
 
 
 def _plot_RFE(rfecv):

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -168,9 +168,19 @@ def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True,
     # generate confusion matrix as pd.DataFrame for viewing
     predictions = pd.DataFrame(cm, index=classes, columns=classes)
     # add empty row/column to show overall accuracy in bottom right cell
+    # baseline error = error rate for a classifier that always guesses the
+    # most common class
+    n_samples = len(y_test)
+    n_samples_largest_class = y_test.value_counts().iloc[0]
+    basline_error = 1 - n_samples_largest_class / n_samples
+    error_ratio = basline_error / (1 - accuracy)
     predictions["Overall Accuracy"] = ""
     predictions.loc["Overall Accuracy"] = ""
+    predictions.loc["Baseline Error"] = ""
+    predictions.loc["Accuracy Ratio"] = ""
     predictions.loc["Overall Accuracy"]["Overall Accuracy"] = accuracy
+    predictions.loc["Baseline Error"]["Overall Accuracy"] = basline_error
+    predictions.loc["Accuracy Ratio"]["Overall Accuracy"] = error_ratio
 
     return predictions, confusion
 


### PR DESCRIPTION
fixes #49 

Here is an example confusion matrix table. what do you think @gregcaporaso ?

![image](https://user-images.githubusercontent.com/1907564/29191698-3655b9a6-7de4-11e7-9c28-3b56743756a0.png)
