### PR TITLE
added new color palette schemes

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -27,7 +27,7 @@ defaults = {
     'n_jobs': 1,
     'n_estimators': 100,
     'estimator_r': 'RandomForestClassifier',
-    'palette': 'Default'
+    'palette': 'sirocco'
 }
 
 

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -12,6 +12,7 @@ from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.sample_data import SampleData
 from .classify import (
     classify_samples, regress_samples, maturity_index)
+from .visuals import _custom_palettes
 import q2_sample_classifier
 from qiime2.plugin import SemanticType
 import qiime2.plugin.model as model
@@ -217,12 +218,7 @@ plugin.visualizers.register_function(
              'GradientBoostingClassifier', 'AdaBoostClassifier',
              'KNeighborsClassifier', 'LinearSVC', 'SVC']),
         'palette': Str % Choices(
-            ['Default', 'Greys', 'Purples', 'Blues', 'Greens', 'Oranges',
-             'Reds', 'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
-             'GnBu', 'PuBu', 'YlGn', 'bone_r', 'pink_r', 'summer_r', 'cool',
-             'hot_r', 'copper_r', 'gist_earth_r', 'terrain_r', 'gnuplot2_r',
-             'cubehelix_r', 'jet_r', 'viridis_r', 'plasma_r', 'inferno_r',
-             'magma_r'])},
+            ['Default', *_custom_palettes().keys()])},
     input_descriptions=input_descriptions,
     parameter_descriptions={
         **parameter_descriptions['base'],

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -217,8 +217,7 @@ plugin.visualizers.register_function(
             ['RandomForestClassifier', 'ExtraTreesClassifier',
              'GradientBoostingClassifier', 'AdaBoostClassifier',
              'KNeighborsClassifier', 'LinearSVC', 'SVC']),
-        'palette': Str % Choices(
-            ['Default', *_custom_palettes().keys()])},
+        'palette': Str % Choices(_custom_palettes().keys())},
     input_descriptions=input_descriptions,
     parameter_descriptions={
         **parameter_descriptions['base'],

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -15,7 +15,8 @@ from warnings import filterwarnings
 from sklearn.exceptions import ConvergenceWarning
 from q2_sample_classifier.visuals import (
     _two_way_anova, _pairwise_stats, _linear_regress,
-    _calculate_baseline_accuracy)
+    _calculate_baseline_accuracy, _custom_palettes,
+    _plot_heatmap_from_confusion_matrix)
 from q2_sample_classifier.classify import (
     classify_samples, regress_samples,
     maturity_index, detect_outliers, predict_coordinates)
@@ -239,6 +240,13 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series(['38.306', '38.306', '38.306', '38.306'],
                         name='Latitude', index=exp_index)
         self.assertEqual(sorted(exp), sorted(obs_category.to_series()))
+
+    # this just checks that palette names are valid input
+    def test_custom_palettes(self):
+        confused = np.array([[1, 0], [0, 1]])
+        for cm in ['Default', *_custom_palettes().keys()]:
+            print(cm)
+            _plot_heatmap_from_confusion_matrix(confused, cm)
 
 
 class EstimatorsTests(SampleClassifierTestPluginBase):

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -244,9 +244,8 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
     # this just checks that palette names are valid input
     def test_custom_palettes(self):
         confused = np.array([[1, 0], [0, 1]])
-        for cm in ['Default', *_custom_palettes().keys()]:
-            print(cm)
-            _plot_heatmap_from_confusion_matrix(confused, cm)
+        for palette in _custom_palettes().keys():
+            _plot_heatmap_from_confusion_matrix(confused, palette)
 
 
 class EstimatorsTests(SampleClassifierTestPluginBase):

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -228,7 +228,7 @@ def split_optimize_classify(features, targets, category, estimator,
                             parameter_tuning=False, param_dist=None,
                             calc_feature_importance=False, load_data=True,
                             scoring=accuracy_score, classification=True,
-                            stratify=True, palette='Default'):
+                            stratify=True, palette='sirocco'):
     # Load, stratify, and split training/test data
     X_train, X_test, y_train, y_test = _prepare_training_data(
         features, targets, category, test_size, random_state,
@@ -316,11 +316,11 @@ def _calculate_feature_importances(X_train, estimator):
 
 
 def _predict_and_plot(output_dir, y_test, y_pred, estimator, accuracy,
-                      classification=True, palette='Default'):
+                      classification=True, palette='sirocco'):
     if classification:
         predictions, predict_plot = _plot_confusion_matrix(
             y_test, y_pred, sorted(estimator.classes_), accuracy,
-            palette=palette)
+            normalize=True, palette=palette)
     else:
         predictions = _linear_regress(y_test, y_pred)
         predict_plot = _regplot_from_dataframe(y_test, y_pred)

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -195,15 +195,12 @@ def _linear_regress(actual, pred):
 
 
 def _plot_heatmap_from_confusion_matrix(cm, palette):
-    if palette == 'Default':
-        palette = _custom_palettes()['sirocco']
-    else:
-        palette = _custom_palettes()[palette]
+    palette = _custom_palettes()[palette]
     return sns.heatmap(cm, cmap=palette)
 
 
-def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True,
-                           palette='Default'):
+def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize,
+                           palette):
 
     cm = confusion_matrix(y_test, y_pred)
     # normalize

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -19,6 +19,55 @@ from itertools import combinations
 from statsmodels.sandbox.stats.multicomp import multipletests
 
 
+def _custom_palettes():
+    return {
+        'YellowOrangeBrown': 'YlOrBr',
+        'YellowOrangeRed': 'YlOrRd',
+        'OrangeRed': 'OrRd',
+        'PurpleRed': 'PuRd',
+        'RedPurple': 'RdPu',
+        'BluePurple': 'BuPu',
+        'GreenBlue': 'GnBu',
+        'PurpleBlue': 'PuBu',
+        'YellowGreen': 'YlGn',
+        'summer': 'summer_r',
+        'copper': 'copper_r',
+        'viridis': 'viridis_r',
+        'plasma': 'plasma_r',
+        'inferno': 'inferno_r',
+        'magma': 'magma_r',
+        'sirocco': sns.cubehelix_palette(
+            dark=0.15, light=0.95, as_cmap=True),
+        'drifting': sns.cubehelix_palette(
+            start=5, rot=0.4, hue=0.8, as_cmap=True),
+        'melancholy': sns.cubehelix_palette(
+            start=25, rot=0.4, hue=0.8, as_cmap=True),
+        'enigma': sns.cubehelix_palette(
+            start=2, rot=0.6, gamma=2.0, hue=0.7, dark=0.45, as_cmap=True),
+        'eros': sns.cubehelix_palette(start=0, rot=0.4, gamma=2.0, hue=2,
+                                      light=0.95, dark=0.5, as_cmap=True),
+        'spectre': sns.cubehelix_palette(
+            start=1.2, rot=0.4, gamma=2.0, hue=1, dark=0.4, as_cmap=True),
+        'ambition': sns.cubehelix_palette(start=2, rot=0.9, gamma=3.0, hue=2,
+                                          light=0.9, dark=0.5, as_cmap=True),
+        'mysteriousstains': sns.light_palette(
+            'baby shit green', input='xkcd', as_cmap=True),
+        'daydream': sns.blend_palette(
+            ['egg shell', 'dandelion'], input='xkcd', as_cmap=True),
+        'solano': sns.blend_palette(
+            ['pale gold', 'burnt umber'], input='xkcd', as_cmap=True),
+        'navarro': sns.blend_palette(
+            ['pale gold', 'sienna', 'pine green'], input='xkcd', as_cmap=True),
+        'dandelions': sns.blend_palette(
+            ['sage', 'dandelion'], input='xkcd', as_cmap=True),
+        'deepblue': sns.blend_palette(
+            ['really light blue', 'petrol'], input='xkcd', as_cmap=True),
+        'verve': sns.cubehelix_palette(
+            start=1.4, rot=0.8, gamma=2.0, hue=1.5, dark=0.4, as_cmap=True),
+        'greyscale': sns.blend_palette(
+            ['light grey', 'dark grey'], input='xkcd', as_cmap=True)}
+
+
 def _regplot_from_dataframe(x, y, plot_style="whitegrid", arb=True,
                             color="grey"):
     '''Seaborn regplot with true 1:1 ratio set by arb (bool).'''
@@ -145,17 +194,24 @@ def _linear_regress(actual, pred):
                         index=[actual.name])
 
 
+def _plot_heatmap_from_confusion_matrix(cm, palette):
+    if palette == 'Default':
+        palette = _custom_palettes()['sirocco']
+    else:
+        palette = _custom_palettes()[palette]
+    return sns.heatmap(cm, cmap=palette)
+
+
 def _plot_confusion_matrix(y_test, y_pred, classes, accuracy, normalize=True,
                            palette='Default'):
-    if palette == 'Default':
-        palette = sns.cubehelix_palette(dark=0.15, light=0.95, as_cmap=True)
 
     cm = confusion_matrix(y_test, y_pred)
     # normalize
     if normalize:
         cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
 
-    confusion = sns.heatmap(cm, cmap=palette)
+    confusion = _plot_heatmap_from_confusion_matrix(cm, palette)
+
     plt.ylabel('True label')
     plt.xlabel('Predicted label')
     confusion.set_xticklabels(classes, rotation=90, ha='center')


### PR DESCRIPTION
Most of the default seaborn color schemes really don't work well for the classification confusion matrix heatmaps. The reason is that these heatmaps contain many values at the extremes and fewer intermediates values, and some colormaps have very bold colors, very dark colors, or black/white at both termini. With the wrong color palette, the results can make your eyes bleed.

So I made my own custom color palettes with softer termini and cheesier names.

Also added a unit test to verify that all color palette names are valid input for `sns.heatmap`.

![q2-sample-classifier-color-schemes](https://user-images.githubusercontent.com/1907564/31462708-2a6fc25a-ae93-11e7-94b1-472be4ba8133.png)
