### PR TITLE
MAINT: Minor cleanup from recent changes

### DIFF
--- a/q2_sample_classifier/__init__.py
+++ b/q2_sample_classifier/__init__.py
@@ -6,27 +6,19 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-import importlib
-
+from ._format import (
+    BooleanSeriesFormat, BooleanSeriesDirectoryFormat,
+    PredictionsFormat, PredictionsDirectoryFormat, ImportanceFormat,
+    ImportanceDirectoryFormat, SampleEstimatorDirFmt, PickleFormat)
+from ._type import BooleanSeries, Predictions, Importance, SampleEstimator
 from ._version import get_versions
+
 
 __version__ = get_versions()['version']
 del get_versions
 
-_format = importlib.import_module('q2_sample_classifier._format')
-BooleanSeriesFormat = _format.BooleanSeriesFormat
-BooleanSeriesDirectoryFormat = _format.BooleanSeriesDirectoryFormat
-PredictionsFormat = _format.PredictionsFormat
-PredictionsDirectoryFormat = _format.PredictionsDirectoryFormat
-ImportanceFormat = _format.ImportanceFormat
-ImportanceDirectoryFormat = _format.ImportanceDirectoryFormat
-SampleEstimatorDirFmt = _format.SampleEstimatorDirFmt
-PickleFormat = _format.PickleFormat
-
-_type = importlib.import_module('q2_sample_classifier._type')
-BooleanSeries = _type.BooleanSeries
-Predictions = _type.Predictions
-Importance = _type.Importance
-SampleEstimator = _type.SampleEstimator
-
-importlib.import_module('q2_sample_classifier._transformer')
+__all__ = ['BooleanSeriesFormat', 'BooleanSeriesDirectoryFormat',
+           'PredictionsFormat', 'PredictionsDirectoryFormat',
+           'ImportanceFormat', 'ImportanceDirectoryFormat',
+           'SampleEstimatorDirFmt', 'PickleFormat', 'BooleanSeries',
+           'Predictions', 'Importance', 'SampleEstimator']

--- a/q2_sample_classifier/_type.py
+++ b/q2_sample_classifier/_type.py
@@ -10,13 +10,7 @@ from qiime2.plugin import SemanticType
 from q2_types.sample_data import SampleData
 from q2_types.feature_data import FeatureData
 
-from .plugin_setup import plugin
-from ._format import (SampleEstimatorDirFmt,
-                      BooleanSeriesDirectoryFormat,
-                      ImportanceDirectoryFormat,
-                      PredictionsDirectoryFormat)
 
-# Semantic Types
 Predictions = SemanticType(
     'Predictions', variant_of=SampleData.field['type'])
 SampleEstimator = SemanticType('SampleEstimator')
@@ -24,23 +18,3 @@ BooleanSeries = SemanticType(
     'BooleanSeries', variant_of=SampleData.field['type'])
 Importance = SemanticType(
     'Importance', variant_of=FeatureData.field['type'])
-
-# Registrations
-plugin.register_semantic_types(
-    SampleEstimator, BooleanSeries, Importance, Predictions)
-
-plugin.register_semantic_type_to_format(
-    SampleEstimator,
-    artifact_format=SampleEstimatorDirFmt)
-
-plugin.register_semantic_type_to_format(
-    SampleData[BooleanSeries],
-    artifact_format=BooleanSeriesDirectoryFormat)
-
-plugin.register_semantic_type_to_format(
-    SampleData[Predictions],
-    artifact_format=PredictionsDirectoryFormat)
-
-plugin.register_semantic_type_to_format(
-    FeatureData[Importance],
-    artifact_format=ImportanceDirectoryFormat)

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -18,6 +18,15 @@ from .classify import (
     classify_samples, regress_samples, maturity_index, regress_samples_ncv,
     classify_samples_ncv, fit_classifier, fit_regressor, split_table)
 from .visuals import _custom_palettes
+from ._format import (SampleEstimatorDirFmt,
+                      BooleanSeriesFormat,
+                      BooleanSeriesDirectoryFormat,
+                      ImportanceFormat,
+                      ImportanceDirectoryFormat,
+                      PredictionsFormat,
+                      PredictionsDirectoryFormat)
+
+from ._type import Predictions, SampleEstimator, BooleanSeries, Importance
 import q2_sample_classifier
 
 citations = Citations.load('citations.bib', package='q2_sample_classifier')
@@ -35,12 +44,6 @@ plugin = Plugin(
         'Plugin for machine learning prediction of sample metadata.'),
     citations=[citations['Bokulich306167']]
 )
-
-_type = importlib.import_module('q2_sample_classifier._type')
-Predictions = _type.Predictions
-SampleEstimator = _type.SampleEstimator
-BooleanSeries = _type.BooleanSeries
-Importance = _type.Importance
 
 description = ('Predicts a {0} sample metadata column using a {1}. Splits '
                'input data into training and test sets. The training set is '
@@ -373,3 +376,25 @@ plugin.visualizers.register_function(
                  'two or more different "treatment" groups.'),
     citations=[citations['subramanian2014persistent']]
 )
+
+
+# Registrations
+plugin.register_semantic_types(
+    SampleEstimator, BooleanSeries, Importance, Predictions)
+plugin.register_semantic_type_to_format(
+    SampleEstimator,
+    artifact_format=SampleEstimatorDirFmt)
+plugin.register_semantic_type_to_format(
+    SampleData[BooleanSeries],
+    artifact_format=BooleanSeriesDirectoryFormat)
+plugin.register_semantic_type_to_format(
+    SampleData[Predictions],
+    artifact_format=PredictionsDirectoryFormat)
+plugin.register_semantic_type_to_format(
+    FeatureData[Importance],
+    artifact_format=ImportanceDirectoryFormat)
+plugin.register_formats(
+    SampleEstimatorDirFmt, BooleanSeriesFormat, BooleanSeriesDirectoryFormat,
+    ImportanceFormat, ImportanceDirectoryFormat, PredictionsFormat,
+    PredictionsDirectoryFormat)
+importlib.import_module('q2_sample_classifier._transformer')

--- a/q2_sample_classifier/tests/data/outliers.tsv
+++ b/q2_sample_classifier/tests/data/outliers.tsv
@@ -3,3 +3,5 @@ a	True
 b	False
 c	True
 d	False
+e	True
+f	False

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -100,9 +100,6 @@ def _load_data(feature_data, targets_metadata, missing_samples):
     index = [ix for ix in feature_data.ids() if ix in index]
     targets = targets.loc[index]
     feature_data = feature_data.filter(index, inplace=False)
-    assert sum(ix1 == ix2 for ix1, ix2 in
-               zip(targets.index, feature_data.ids())) == len(targets.index) \
-        and len(targets.index) == len(feature_data.ids())
     feature_data = _extract_features(feature_data)
 
     return feature_data, targets


### PR DESCRIPTION
Fixes #103 

The changes in this PR represent my review of the changes merged as part of #100/#101.

---

- Removed errant `assert`
- Cleaned up circular imports
- Revised new formats
- Added some tests