### PR TITLE
split on metadata, fix split_table bug

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -229,10 +229,10 @@ def maturity_index(output_dir: str, table: biom.Table,
 
     # split input data into control and treatment groups
     table, metadata = _load_data(
-        table, metadata, missing_samples=missing_samples)
+        table, metadata, missing_samples=missing_samples, extract=False)
     fancy_index = metadata[group_by] == control
     md_control = metadata[fancy_index]
-    table_control = [t for t, f in zip(table, fancy_index) if f]
+    table_control = table.filter(md_control.index, inplace=False)
 
     # train model on control data
     estimator, cm, accuracy, importances = split_optimize_classify(
@@ -246,6 +246,7 @@ def maturity_index(output_dir: str, table: biom.Table,
 
     # predict treatment data
     index = importances.index
+    table = _extract_features(table)
     table = [{k: r[k] for k in r.keys() & index} for r in table]
     y_pred = estimator.predict(table)
     predicted_column = 'predicted {0}'.format(column)

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -43,6 +43,7 @@ from q2_types.feature_data import FeatureData
 import pkg_resources
 from qiime2.plugin.testing import TestPluginBase
 from qiime2.plugin import ValidationError
+from qiime2.plugins import sample_classifier
 import sklearn
 from sklearn.metrics import mean_squared_error
 from sklearn.ensemble import RandomForestClassifier, AdaBoostClassifier
@@ -679,13 +680,13 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
         X_train, X_test = split_table(
             self.table_chard_fp, self.mdc_chard_fp, test_size=0.5,
             random_state=123, stratify=True, missing_samples='ignore')
-        self.assertEqual(len(X_train) + len(X_test), 21)
+        self.assertEqual(len(X_train.ids()) + len(X_test.ids()), 21)
 
     def test_split_table_no_split(self):
         X_train, X_test = split_table(
             self.table_chard_fp, self.mdc_chard_fp, test_size=0.0,
             random_state=123, stratify=True, missing_samples='ignore')
-        self.assertEqual(len(X_train), 21)
+        self.assertEqual(len(X_train.ids()), 21)
 
     def test_split_table_invalid_test_size(self):
         with self.assertRaisesRegex(ValueError, "at least two samples"):
@@ -762,6 +763,28 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
             # as we would expect)
             mse = mean_squared_error(exp, pred)
             self.assertAlmostEqual(mse, seeded_predict_results[regressor])
+
+
+class NowLetsTestTheActions(SampleClassifierTestPluginBase):
+
+    def setUp(self):
+        super().setUp()
+        md = pd.Series(['a', 'a', 'b', 'b', 'b'],
+                       index=['a', 'b', 'c', 'd', 'e'], name='bugs')
+        md.index.name = 'SampleID'
+        self.md = qiime2.CategoricalMetadataColumn(md)
+        tab = biom.Table(
+            np.array([[3, 6, 7, 3, 6], [3, 4, 5, 6, 2], [8, 6, 4, 1, 0],
+                      [8, 6, 4, 1, 0], [8, 6, 4, 1, 0]]),
+            observation_ids=['v', 'w', 'x', 'y', 'z'],
+            sample_ids=['a', 'b', 'c', 'd', 'e'])
+        self.tab = qiime2.Artifact.import_data('FeatureTable[Frequency]', tab)
+
+    # let's make sure the correct transformers are in place! See issue 114
+    # if this runs without error, that's good enough for me. We already
+    # validate the function above.
+    def test_action_split_table(self):
+        sample_classifier.actions.split_table(self.tab, self.md, test_size=0.5)
 
 
 class SampleEstimatorTestBase(SampleClassifierTestPluginBase):

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -82,7 +82,7 @@ def _extract_features(feature_data):
     return features
 
 
-def _load_data(feature_data, targets_metadata, missing_samples):
+def _load_data(feature_data, targets_metadata, missing_samples, extract=True):
     '''Load data and generate training and test sets.
 
     feature_data: pd.DataFrame
@@ -101,7 +101,8 @@ def _load_data(feature_data, targets_metadata, missing_samples):
     index = [ix for ix in feature_data.ids() if ix in index]
     targets = targets.loc[index]
     feature_data = feature_data.filter(index, inplace=False)
-    feature_data = _extract_features(feature_data)
+    if extract:
+        feature_data = _extract_features(feature_data)
 
     return feature_data, targets
 
@@ -141,7 +142,7 @@ def _split_training_data(feature_data, targets, column, test_size=0.2,
                          stratify=None, random_state=None, drop_na=True):
     '''Split data sets into training and test sets.
 
-    feature_data: pandas.DataFrame
+    feature_data: biom.Table
         feature X sample values.
     targets: pandas.DataFrame
         target (columns) X sample (rows) values.
@@ -159,37 +160,44 @@ def _split_training_data(feature_data, targets, column, test_size=0.2,
     targets = targets[column]
 
     if drop_na:
-        try:
-            targets, feature_data = \
-                zip(*[(t, f) for t, f in zip(targets, feature_data)
-                      if pd.notna(t)])
-        except ValueError:
-            targets, feature_data = [], []
-        targets = pd.Series(targets)
-        targets.name = column
+        targets = targets.dropna()
 
     if test_size > 0.0:
         try:
-            X_train, X_test, y_train, y_test = train_test_split(
-                feature_data, targets, test_size=test_size, stratify=stratify,
+            y_train, y_test = train_test_split(
+                targets, test_size=test_size, stratify=stratify,
                 random_state=random_state)
         except ValueError:
-            raise ValueError((
-                'You have chosen to predict a metadata column that contains '
-                'one or more values that match only one sample. For proper '
-                'stratification of data into training and test sets, each '
-                'class (value) must contain at least two samples. This is a '
-                'requirement for classification problems, but stratification '
-                'can be disabled for regression by setting stratify=False. '
-                'Alternatively, remove all samples that bear a unique class '
-                'label for your chosen metadata column. Note that disabling '
-                'stratification can negatively impact predictive accuracy for '
-                'small data sets.'))
+            _stratification_error()
     else:
         X_train, X_test, y_train, y_test = (
             feature_data, feature_data, targets, targets)
 
+    tri = y_train.index
+    # filter and sort biom tables to match split/filtered metadata ids
+    # skip filtering if no splitting/dropna was performed
+    # if test_size > 0.0 is implicit, so don't need to worry about initializing
+    # X_train and X_test in an else statement.
+    if list(tri) != list(feature_data.ids()):
+        tei = y_test.index
+        X_train = feature_data.filter(tri, inplace=False).sort_order(tri)
+        X_test = feature_data.filter(tei, inplace=False).sort_order(tei)
+
     return X_train, X_test, y_train, y_test
+
+
+def _stratification_error():
+    raise ValueError((
+        'You have chosen to predict a metadata column that contains '
+        'one or more values that match only one sample. For proper '
+        'stratification of data into training and test sets, each '
+        'class (value) must contain at least two samples. This is a '
+        'requirement for classification problems, but stratification '
+        'can be disabled for regression by setting stratify=False. '
+        'Alternatively, remove all samples that bear a unique class '
+        'label for your chosen metadata column. Note that disabling '
+        'stratification can negatively impact predictive accuracy for '
+        'small data sets.'))
 
 
 def _rfecv_feature_selection(feature_data, targets, estimator,
@@ -200,7 +208,7 @@ def _rfecv_feature_selection(feature_data, targets, estimator,
     __________
     Parameters
     __________
-    feature_data: pandas.DataFrame
+    feature_data: list of dicts
         Training set feature data x samples.
     targets: pandas.DataFrame
         Training set target value data x samples.
@@ -340,6 +348,8 @@ def split_optimize_classify(features, targets, column, estimator,
         features, targets, column, test_size, random_state,
         load_data=load_data, stratify=stratify,
         missing_samples=missing_samples)
+    X_train = _extract_features(X_train)
+    X_test = _extract_features(X_test)
 
     # optimize training feature count
     if optimize_feature_selection:
@@ -392,7 +402,7 @@ def _prepare_training_data(features, targets, column, test_size,
     # load data
     if load_data:
         features, targets = _load_data(
-            features, targets, missing_samples=missing_samples)
+            features, targets, missing_samples=missing_samples, extract=False)
 
     # split into training and test sets
     if stratify:
@@ -401,8 +411,7 @@ def _prepare_training_data(features, targets, column, test_size,
         strata = None
 
     X_train, X_test, y_train, y_test = _split_training_data(
-        features, targets, column, test_size, strata,
-        random_state)
+        features, targets, column, test_size, strata, random_state)
 
     return X_train, X_test, y_train, y_test
 


### PR DESCRIPTION
fixes #105 
fixes #114 

I added a test for the `split_table` action itself, but it should be unnecessary — the function tests now specifically test a `biom.Table` output — before the output was `pd.DataFrame` and then list of dicts, so there was ambiguity that allowed #114 to slip by undetected. Let me know if I should drop that.