### PR TITLE
joss paper: fixed reference name inconsistency

### DIFF
--- a/paper/references.bib
+++ b/paper/references.bib
@@ -145,7 +145,7 @@
 @ARTICLE{Bokulich2013-go,
   title   = "Microbial biogeography of wine grapes
              is conditioned by cultivar, vintage, and climate",
-  author  = "Bokulich, N A and Thorngate, J H and Richardson, P M and Mills, D
+  author  = "Bokulich, Nicholas A and Thorngate, J H and Richardson, P M and Mills, D
              A",
   journal = "Proceedings of the National Academy of Sciences",
   volume  =  111,


### PR DESCRIPTION
this presumably was the cause of reference formatting inconsistency in the pdf preview.