### PR TITLE
metatable method: convert/merge metadata into feature table

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -46,6 +46,8 @@ def metatable(ctx,
     metadata = metadata.filter_columns(
         column_type='numeric', drop_all_unique=True, drop_zero_variance=True,
         drop_all_missing=True).to_dataframe()
+    # drop columns with negative values
+    metadata = metadata[-(metadata < 0).any(axis=1)]
 
     if missing_values == 'drop_samples':
         metadata = metadata.dropna(axis=0)
@@ -64,6 +66,9 @@ def metatable(ctx,
         raise ValueError('All metadata columns have been filtered.')
     if len(metadata.index) == 0:
         raise ValueError('All metadata samples have been filtered.')
+    print(metadata)
+    print(len(metadata.columns))
+    print(len(metadata.index))
 
     # only retain IDs that intersect with table
     if table is not None:

--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -66,9 +66,6 @@ def metatable(ctx,
         raise ValueError('All metadata columns have been filtered.')
     if len(metadata.index) == 0:
         raise ValueError('All metadata samples have been filtered.')
-    print(metadata)
-    print(len(metadata.columns))
-    print(len(metadata.index))
 
     # only retain IDs that intersect with table
     if table is not None:

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -20,7 +20,7 @@ from .classify import (
     regress_samples_ncv,
     classify_samples_ncv, fit_classifier, fit_regressor, split_table,
     predict_classification, predict_regression, confusion_matrix, scatterplot,
-    summarize)
+    summarize, metatable)
 from .visuals import _custom_palettes
 from ._format import (SampleEstimatorDirFmt,
                       BooleanSeriesFormat,
@@ -487,6 +487,36 @@ plugin.visualizers.register_function(
          'trained estimator.',
     description='Summarize parameter and feature extraction information for a '
                 'trained estimator.'
+)
+
+
+plugin.pipelines.register_function(
+    function=metatable,
+    inputs=inputs,
+    parameters={'metadata': Metadata,
+                'missing_samples': parameters['base']['missing_samples']},
+    outputs=[('table', FeatureTable[Frequency])],
+    input_descriptions=input_descriptions,
+    parameter_descriptions={
+        'metadata': 'Metadata file to convert to feature table.',
+        'missing_samples': parameter_descriptions['base']['missing_samples'],
+    },
+    output_descriptions={'table': 'Converted feature table'},
+    name='Convert (and merge) positive numeric metadata (in)to feature table.',
+    description='Convert numeric sample metadata from TSV file into a feature '
+                'table. Optionally merge with an existing feature table. Only '
+                'numeric metadata will be converted; categorical columns will '
+                'be silently dropped. By default, if a table is used as input '
+                'only samples found in both the table and metadata '
+                '(intersection) are merged, and others are silently dropped. '
+                'Set missing_samples="error" to raise an error if samples '
+                'found in the table are missing from the metadata file. The '
+                'metadata file can always contain a superset of samples. Note '
+                'that columns will be dropped if they are non-numeric, '
+                'contain only unique values, contain no unique values (zero '
+                'variance), contain only empty cells, or contain negative '
+                'values. This method currently only converts '
+                'postive numeric metadata into feature data.'
 )
 
 

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -516,7 +516,9 @@ plugin.pipelines.register_function(
                 'contain only unique values, contain no unique values (zero '
                 'variance), contain only empty cells, or contain negative '
                 'values. This method currently only converts '
-                'postive numeric metadata into feature data.'
+                'postive numeric metadata into feature data. Tip: convert '
+                'categorical columns to dummy variables to include them in '
+                'the output feature table.'
 )
 
 

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -495,13 +495,13 @@ plugin.pipelines.register_function(
     inputs=inputs,
     parameters={'metadata': Metadata,
                 'missing_samples': parameters['base']['missing_samples']},
-    outputs=[('table', FeatureTable[Frequency])],
+    outputs=[('converted_table', FeatureTable[Frequency])],
     input_descriptions=input_descriptions,
     parameter_descriptions={
         'metadata': 'Metadata file to convert to feature table.',
         'missing_samples': parameter_descriptions['base']['missing_samples'],
     },
-    output_descriptions={'table': 'Converted feature table'},
+    output_descriptions={'converted_table': 'Converted feature table'},
     name='Convert (and merge) positive numeric metadata (in)to feature table.',
     description='Convert numeric sample metadata from TSV file into a feature '
                 'table. Optionally merge with an existing feature table. Only '

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -494,12 +494,19 @@ plugin.pipelines.register_function(
     function=metatable,
     inputs=inputs,
     parameters={'metadata': Metadata,
-                'missing_samples': parameters['base']['missing_samples']},
+                'missing_samples': parameters['base']['missing_samples'],
+                'missing_values': Str % Choices(
+                    ['drop_samples', 'drop_features', 'error', 'fill'])},
     outputs=[('converted_table', FeatureTable[Frequency])],
     input_descriptions=input_descriptions,
     parameter_descriptions={
         'metadata': 'Metadata file to convert to feature table.',
         'missing_samples': parameter_descriptions['base']['missing_samples'],
+        'missing_values': (
+            'How to handle missing values (nans) in metadata. Either '
+            '"drop_samples" with missing values, "drop_features" with missing '
+            'values, "fill" missing values with zeros, or "error" if '
+            'any missing values are found.')
     },
     output_descriptions={'converted_table': 'Converted feature table'},
     name='Convert (and merge) positive numeric metadata (in)to feature table.',

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -908,7 +908,6 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
             sample_ids=['a', 'b', 'c', 'd', 'e', 'peanut'])
         res, = sample_classifier.actions.metatable(self.md2)
         report = res.view(biom.Table).descriptive_equality(exp)
-        print(res.view(pd.DataFrame))
         self.assertIn('Tables appear equal', report, report)
 
     def test_metatable_with_merge(self):
@@ -921,7 +920,6 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
             sample_ids=['a', 'b', 'c', 'd', 'e'])
         res, = sample_classifier.actions.metatable(self.md2, self.tab)
         report = res.view(biom.Table).descriptive_equality(exp)
-        print(res.view(pd.DataFrame))
         self.assertIn('Tables appear equal', report, report)
 
     def test_metatable_with_merge_successful_inner_join(self):
@@ -934,7 +932,6 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
         res, = sample_classifier.actions.metatable(
             self.md2.filter_ids(['a', 'b', 'c', 'd']), self.tab)
         report = res.view(biom.Table).descriptive_equality(exp)
-        print(res.view(pd.DataFrame))
         self.assertIn('Tables appear equal', report, report)
 
     def test_metatable_with_merge_error_inner_join(self):

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -986,6 +986,20 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
                 self.md2.filter_ids(['b', 'c']), self.tab,
                 missing_values='drop_samples')
 
+    def test_metatable_no_samples_after_filtering(self):
+        junk_md = pd.DataFrame(
+            {'trash': ['a', 'a', 'b', 'b', 'b', 'junk'],
+             'floats': [np.nan, np.nan, np.nan, 1.8, 1000.1, 0.1],
+             'ints': [0, 1, 2, np.nan, 2, 0],
+             'nans': [1, 1, 2, 2, np.nan, np.nan],
+             'negatives': [-7, -4, -1.2, -4, -9, -1]},
+            index=['a', 'b', 'c', 'd', 'e', 'peanut'])
+        junk_md.index.name = 'SampleID'
+        junk_md = qiime2.Metadata(junk_md)
+        with self.assertRaisesRegex(ValueError, "All metadata samples"):
+            sample_classifier.actions.metatable(
+                junk_md, missing_values='drop_samples')
+
 
 class SampleEstimatorTestBase(SampleClassifierTestPluginBase):
     package = 'q2_sample_classifier.tests'


### PR DESCRIPTION
fixes #85 

This is a temporary fix. This method does not operate on negative values, which could be potentially important. Positive numeric still covers most use cases, so I think it is worth considering this method.