### PR TITLE
added joblib dependency

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python {{ python }}
     - pandas
     - scipy
+    - joblib
     - scikit-learn
     - scikit-bio
     - seaborn >=0.8

--- a/q2_sample_classifier/_transformer.py
+++ b/q2_sample_classifier/_transformer.py
@@ -15,7 +15,7 @@ import numpy as np
 import qiime2
 import qiime2.plugin.model as model
 import sklearn
-from sklearn.externals import joblib
+import joblib
 from sklearn.pipeline import Pipeline
 
 from .plugin_setup import plugin

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -53,7 +53,7 @@ from sklearn.svm import LinearSVC, LinearSVR
 from sklearn.feature_extraction import DictVectorizer
 from sklearn.feature_selection import RFECV
 from sklearn.pipeline import Pipeline
-from sklearn.externals import joblib
+import joblib
 import pandas.util.testing as pdt
 import biom
 import skbio


### PR DESCRIPTION
sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23, so adding joblib as a dependency.

IGNORE THE TRAVIS FAILURES, THIS IS DUE TO AN UNRELATED ISSUE (🐼 problems?)