### PR TITLE
fixed some DeprecationWarning and other warnings, updated SVMs

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -423,11 +423,13 @@ def detect_outliers(table: biom.Table,
         X_train = features
 
     # fit isolation tree
+    # TODO: update to behavior='new' if we ever move this out of experimental
     estimator = Pipeline(
         [('dv', DictVectorizer()),
          ('est', IsolationForest(n_jobs=n_jobs, n_estimators=n_estimators,
                                  contamination=contamination,
-                                 random_state=random_state))])
+                                 random_state=random_state,
+                                 behaviour='old'))])
     estimator.fit(X_train)
 
     # predict outlier status

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -317,7 +317,8 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([True, False, True, False, True, False],
                         name='outlier', index=exp_index)
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
+                                 squeeze=True)
         self.assertEqual(sorted(exp), sorted(obs))
 
     def test_boolean_format_to_pd_series(self):
@@ -377,7 +378,8 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([1, 2, 3, 4],
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
+                                 squeeze=True)
         pdt.assert_series_equal(obs, exp)
 
     def test_pd_series_to_Predictions_format_allow_nans(self):
@@ -385,7 +387,8 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([1, np.nan, 3, np.nan],
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
+                                 squeeze=True)
         pdt.assert_series_equal(obs, exp)
 
     def test_Predictions_format_to_pd_series(self):
@@ -540,9 +543,9 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
         self.exp_imp = pd.read_csv(
             self.get_data_path('importance.tsv'), sep='\t', header=0,
             index_col=0)
-        self.exp_pred = pd.Series.from_csv(
+        self.exp_pred = pd.read_csv(
             self.get_data_path('predictions.tsv'), sep='\t', header=0,
-            index_col=0)
+            index_col=0, squeeze=True)
         index = pd.Index(['A', 'B', 'C', 'D'], name='id')
         self.table_percnorm = qiime2.Artifact.import_data(
             FeatureTable[PercentileNormalized], pd.DataFrame(

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -323,7 +323,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
                         name='outlier', index=exp_index)
         obs = transformer(exp)
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
-                                 squeeze=True)
+                          squeeze=True)
         self.assertEqual(sorted(exp), sorted(obs))
 
     def test_boolean_format_to_pd_series(self):
@@ -384,7 +384,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
-                                 squeeze=True)
+                          squeeze=True)
         pdt.assert_series_equal(obs, exp)
 
     def test_pd_series_to_Predictions_format_allow_nans(self):
@@ -393,7 +393,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
         obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
-                                 squeeze=True)
+                          squeeze=True)
         pdt.assert_series_equal(obs, exp)
 
     def test_Predictions_format_to_pd_series(self):

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -123,15 +123,18 @@ class UtilitiesTests(SampleClassifierTestPluginBase):
     # test feature importance calculation with main classifier types
     def test_calculate_feature_importances_ensemble(self):
         estimator = Pipeline(
-            [('dv', DictVectorizer()), ('est', RandomForestClassifier())])
-        estimator.fit(_extract_features(self.features), self.targets)
+            [('dv', DictVectorizer()),
+             ('est', RandomForestClassifier(n_estimators=10))])
+        estimator.fit(_extract_features(self.features),
+                      self.targets.values.ravel())
         fi = _calculate_feature_importances(estimator)
         self.assertEqual(sorted(self.exp_rf), sorted(fi))
 
     def test_calculate_feature_importances_svm(self):
         estimator = Pipeline(
             [('dv', DictVectorizer()), ('est', LinearSVC())])
-        estimator.fit(_extract_features(self.features), self.targets)
+        estimator.fit(_extract_features(self.features),
+                      self.targets.values.ravel())
         fi = _calculate_feature_importances(estimator)
         self.assertEqual(sorted(self.exp_lsvm), sorted(fi))
 
@@ -226,7 +229,7 @@ class TestRFEExtractor(SampleClassifierTestPluginBase):
 
     def extract_rfe_scores_template(self, steps, expected):
         selector = RFECV(LinearSVR(random_state=123), step=steps, cv=2)
-        selector = selector.fit(self.X, self.y)
+        selector = selector.fit(self.X, self.y.ravel())
         pdt.assert_series_equal(
             _extract_rfe_scores(selector), expected, check_less_precise=3)
 
@@ -314,7 +317,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([True, False, True, False, True, False],
                         name='outlier', index=exp_index)
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
         self.assertEqual(sorted(exp), sorted(obs))
 
     def test_boolean_format_to_pd_series(self):
@@ -374,7 +377,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([1, 2, 3, 4],
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
         pdt.assert_series_equal(obs, exp)
 
     def test_pd_series_to_Predictions_format_allow_nans(self):
@@ -382,7 +385,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.Series([1, np.nan, 3, np.nan],
                         name='prediction', index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.Series.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.Series.from_csv(str(obs), sep='\t', header=0, index_col=0)
         pdt.assert_series_equal(obs, exp)
 
     def test_Predictions_format_to_pd_series(self):
@@ -448,7 +451,7 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
         exp = pd.DataFrame([1, 2, 3, 4],
                            columns=['importance'], index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.DataFrame.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0)
         pdt.assert_frame_equal(exp, obs)
 
     def test_Importance_format_to_pd_dataframe(self):
@@ -512,19 +515,19 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
 
         def _load_md(md_fp):
             md_fp = self.get_data_path(md_fp)
-            md = pd.DataFrame.from_csv(md_fp, sep='\t')
+            md = pd.read_csv(md_fp, sep='\t', header=0, index_col=0)
             md = qiime2.Metadata(md)
             return md
 
         def _load_nmc(md_fp, column):
             md_fp = self.get_data_path(md_fp)
-            md = pd.DataFrame.from_csv(md_fp, sep='\t')
+            md = pd.read_csv(md_fp, sep='\t', header=0, index_col=0)
             md = qiime2.NumericMetadataColumn(md[column])
             return md
 
         def _load_cmc(md_fp, column):
             md_fp = self.get_data_path(md_fp)
-            md = pd.DataFrame.from_csv(md_fp, sep='\t')
+            md = pd.read_csv(md_fp, sep='\t', header=0, index_col=0)
             md = qiime2.CategoricalMetadataColumn(md[column])
             return md
 
@@ -534,10 +537,12 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
         self.table_ecam_fp = _load_biom('ecam-table-maturity.qza')
         self.md_ecam_fp = _load_md('ecam_map_maturity.txt')
         self.mdc_ecam_fp = _load_nmc('ecam_map_maturity.txt', 'month')
-        self.exp_imp = pd.DataFrame.from_csv(
-            self.get_data_path('importance.tsv'), sep='\t')
+        self.exp_imp = pd.read_csv(
+            self.get_data_path('importance.tsv'), sep='\t', header=0,
+            index_col=0)
         self.exp_pred = pd.Series.from_csv(
-            self.get_data_path('predictions.tsv'), sep='\t', header=0)
+            self.get_data_path('predictions.tsv'), sep='\t', header=0,
+            index_col=0)
         index = pd.Index(['A', 'B', 'C', 'D'], name='id')
         self.table_percnorm = qiime2.Artifact.import_data(
             FeatureTable[PercentileNormalized], pd.DataFrame(
@@ -704,8 +709,9 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
         pipeline, importances = fit_regressor(
             self.table_ecam_fp, self.mdc_ecam_fp, random_state=123,
             n_estimators=2, n_jobs=1, missing_samples='ignore')
-        exp_imp = pd.DataFrame.from_csv(
-            self.get_data_path('importance_cv.tsv'), sep='\t')
+        exp_imp = pd.read_csv(
+            self.get_data_path('importance_cv.tsv'), sep='\t', header=0,
+            index_col=0)
         pdt.assert_frame_equal(importances, exp_imp)
 
     # just make sure this method runs. Uses the same internal function as
@@ -897,8 +903,9 @@ class TestHeatmap(SampleClassifierTestPluginBase):
         table_ecam = qiime2.Artifact.load(table_ecam)
         self.table_ecam, = feature_table.actions.filter_samples(
             table_ecam, metadata=md_ecam)
-        imp = pd.DataFrame.from_csv(
-            self.get_data_path('importance.tsv'), sep='\t')
+        imp = pd.read_csv(
+            self.get_data_path('importance.tsv'), sep='\t', header=0,
+            index_col=0)
         self.imp = qiime2.Artifact.import_data('FeatureData[Importance]', imp)
 
     def test_heatmap_default_feature_count_zero(self):
@@ -1070,7 +1077,7 @@ class SampleEstimatorTestBase(SampleClassifierTestPluginBase):
 
         def _load_cmc(md_fp, column):
             md_fp = self.get_data_path(md_fp)
-            md = pd.DataFrame.from_csv(md_fp, sep='\t')
+            md = pd.read_csv(md_fp, sep='\t', header=0, index_col=0)
             md = qiime2.CategoricalMetadataColumn(md[column])
             return md
 
@@ -1303,7 +1310,7 @@ seeded_results = {
     'GradientBoostingClassifier': 0.272727272727,
     'AdaBoostClassifier': 0.272727272727,
     'LinearSVC': 0.727272727273,
-    'SVC': 0.545454545455,
+    'SVC': 0.36363636363636365,
     'KNeighborsClassifier': 0.363636363636,
     'RandomForestRegressor': 23.226508,
     'ExtraTreesRegressor': 19.725397,
@@ -1314,7 +1321,7 @@ seeded_results = {
     'ElasticNet': 618.532273,
     'KNeighborsRegressor': 44.7847619048,
     'LinearSVR': 511.816385601,
-    'SVR': 72.6666666667}
+    'SVR': 51.325146}
 
 seeded_predict_results = {
     'RandomForestClassifier': 18,
@@ -1322,7 +1329,7 @@ seeded_predict_results = {
     'GradientBoostingClassifier': 21,
     'AdaBoostClassifier': 21,
     'LinearSVC': 21,
-    'SVC': 21,
+    'SVC': 12,
     'KNeighborsClassifier': 14,
     'RandomForestRegressor': 7.4246031746,
     'ExtraTreesRegressor': 0.,
@@ -1332,5 +1339,5 @@ seeded_predict_results = {
     'Ridge': 7.57617215386,
     'ElasticNet': 0.0614243397637,
     'KNeighborsRegressor': 26.8625396825,
-    'SVR': 59.7152380952,
+    'SVR': 37.86704865859832,
     'LinearSVR': 0.0099912565770459132}

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -237,7 +237,7 @@ def _rfecv_feature_selection(feature_data, targets, estimator,
          ('est', RFECV(estimator=estimator.named_steps.est, step=step, cv=cv,
                        scoring=scoring, n_jobs=n_jobs))])
 
-    rfecv.fit(feature_data, targets)
+    rfecv.fit(feature_data, targets.values.ravel())
 
     # Describe top features
     n_opt = rfecv.named_steps.est.n_features_
@@ -335,7 +335,7 @@ def _fit_estimator(features, targets, estimator, n_estimators=100, step=0.05,
             n_jobs=n_jobs, cv=cv, random_state=random_state).best_estimator_
 
     # fit estimator
-    estimator.fit(X_train, y_train)
+    estimator.fit(X_train, y_train.values.ravel())
 
     importances = _attempt_to_calculate_feature_importances(
         estimator, calc_feature_importance,
@@ -564,7 +564,7 @@ def _tune_parameters(X_train, y_train, estimator, param_dist, n_iter_search=20,
     random_search = RandomizedSearchCV(
         estimator, param_distributions=param_dist, n_iter=n_iter_search,
         n_jobs=n_jobs, cv=cv, random_state=random_state)
-    random_search.fit(X_train, y_train)
+    random_search.fit(X_train, y_train.values.ravel())
     return random_search
 
 
@@ -603,7 +603,7 @@ def _fit_and_predict_cv(table, metadata, estimator, param_dist, n_jobs,
                 random_state=random_state).best_estimator_
         else:
             # fit estimator on inner outer training set
-            estimator.fit(X_train, y_train)
+            estimator.fit(X_train, y_train.values.ravel())
         # predict values for outer loop test set
         test_set = features[test_index]
         index = metadata.iloc[test_index]
@@ -681,7 +681,7 @@ def _select_estimator(estimator, n_jobs, n_estimators, random_state=None):
             n_estimators=n_estimators, random_state=random_state)
     elif estimator == 'SVR':
         param_dist = {**parameters['svm'], 'epsilon': [0.0, 0.1]}
-        estimator = SVR(kernel='rbf')
+        estimator = SVR(kernel='rbf', gamma='scale')
     elif estimator == 'LinearSVR':
         param_dist = {**parameters['svm'], 'epsilon': [0.0, 0.1]}
         estimator = SVR(kernel='linear')
@@ -720,7 +720,7 @@ def _select_estimator(estimator, n_jobs, n_estimators, random_state=None):
         estimator = LinearSVC(random_state=random_state)
     elif estimator == 'SVC':
         param_dist = parameters['svm']
-        estimator = SVC(kernel='rbf', random_state=random_state)
+        estimator = SVC(kernel='rbf', random_state=random_state, gamma='scale')
     elif estimator == 'KNeighborsClassifier':
         param_dist = parameters['kneighbors']
         estimator = KNeighborsClassifier(algorithm='auto')


### PR DESCRIPTION
Heading off various warnings not already fixed by #152 and #151 

Travis will fail: these are the 6 tests fixed in #152 

NOTE: SVM estimators were updated to use `gamma=scale` by default (in advance of future changes to that default). This does change prediction results, as reflected in the diff. No other changes altered the expected test results.