### PR TITLE
IMP: Add ability to adjust heatmap colorscale

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -357,6 +357,7 @@ def confusion_matrix(output_dir: str,
                      probabilities: pd.DataFrame = None,
                      missing_samples: str = defaults['missing_samples'],
                      vmin: int = 'auto', vmax: int = 'auto',
+                     mask: bool = False,
                      palette: str = defaults['palette']) -> None:
     if vmin == 'auto':
         vmin = None
@@ -368,7 +369,8 @@ def confusion_matrix(output_dir: str,
     _plot_accuracy(output_dir, predictions, truth, probabilities,
                    missing_samples=missing_samples,
                    classification=True, palette=palette,
-                   plot_title='confusion matrix', vmin=vmin, vmax=vmax)
+                   plot_title='confusion matrix', vmin=vmin, vmax=vmax,
+                   mask=False)
 
 
 def summarize(output_dir: str, sample_estimator: Pipeline):

--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -357,20 +357,16 @@ def confusion_matrix(output_dir: str,
                      probabilities: pd.DataFrame = None,
                      missing_samples: str = defaults['missing_samples'],
                      vmin: int = 'auto', vmax: int = 'auto',
-                     mask: bool = False,
                      palette: str = defaults['palette']) -> None:
     if vmin == 'auto':
         vmin = None
     if vmax == 'auto':
         vmax = None
-    if vmin is not None and vmax is not None and vmin > vmax:
-        raise ValueError(
-            'Value passed for vmin must be less than or equal to vmax')
+
     _plot_accuracy(output_dir, predictions, truth, probabilities,
                    missing_samples=missing_samples,
                    classification=True, palette=palette,
-                   plot_title='confusion matrix', vmin=vmin, vmax=vmax,
-                   mask=False)
+                   plot_title='confusion matrix', vmin=vmin, vmax=vmax)
 
 
 def summarize(output_dir: str, sample_estimator: Pipeline):

--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -356,11 +356,19 @@ def confusion_matrix(output_dir: str,
                      truth: qiime2.CategoricalMetadataColumn,
                      probabilities: pd.DataFrame = None,
                      missing_samples: str = defaults['missing_samples'],
+                     vmin: int = 'auto', vmax: int = 'auto',
                      palette: str = defaults['palette']) -> None:
+    if vmin == 'auto':
+        vmin = None
+    if vmax == 'auto':
+        vmax = None
+    if vmin is not None and vmax is not None and vmin > vmax:
+        raise ValueError(
+            'Value passed for vmin must be less than or equal to vmax')
     _plot_accuracy(output_dir, predictions, truth, probabilities,
                    missing_samples=missing_samples,
                    classification=True, palette=palette,
-                   plot_title='confusion matrix')
+                   plot_title='confusion matrix', vmin=vmin, vmax=vmax)
 
 
 def summarize(output_dir: str, sample_estimator: Pipeline):

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -456,8 +456,10 @@ plugin.visualizers.register_function(
     parameter_descriptions={
         'truth': 'Metadata column (true values) to plot on y axis.',
         'missing_samples': parameter_descriptions['base']['missing_samples'],
-        'vmin': 'The minimum color value for the heatmap',
-        'vmax': 'The maximum color value for the heatmap',
+        'vmin': 'The minimum value to use for anchoring the colormap. If '
+        '"auto", vmin is set to the minimum value in the data.',
+        'vmax': 'The maximum value to use for anchoring the colormap. If '
+        '"auto", vmax is set to the maximum value in the data.',
         'palette': 'The color palette to use for plotting.'},
     name='Make a confusion matrix from sample classifier predictions.',
     description='Make a confusion matrix and calculate accuracy of predicted '

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -10,7 +10,7 @@ import importlib
 
 from qiime2.plugin import (
     Int, Str, Float, Range, Bool, Plugin, Metadata, Choices, MetadataColumn,
-    Numeric, Categorical, Citations, Visualization, TypeMatch)
+    Numeric, Categorical, Citations, Visualization, TypeMatch, TypeMap)
 from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Balance,
     PercentileNormalized)
@@ -437,7 +437,10 @@ plugin.visualizers.register_function(
                 'regressor.'
 )
 
-
+vmin_vmax, mask, __ = TypeMap({
+    (Float, Bool % Choices(False)): Visualization,
+    (Str % Choices('auto'), Bool): Visualization,
+})
 plugin.visualizers.register_function(
     function=confusion_matrix,
     inputs={'predictions': SampleData[ClassifierPredictions],
@@ -445,8 +448,9 @@ plugin.visualizers.register_function(
     parameters={
         'truth': MetadataColumn[Categorical],
         'missing_samples': parameters['base']['missing_samples'],
-        'vmin': Float | Str % Choices(['auto']),
-        'vmax': Float | Str % Choices(['auto']),
+        'vmin': vmin_vmax,
+        'vmax': vmin_vmax,
+        'mask': mask,
         'palette': Str % Choices(_custom_palettes().keys())},
     input_descriptions={
         'predictions': 'Predicted values to plot on x axis. Should be '

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -10,7 +10,7 @@ import importlib
 
 from qiime2.plugin import (
     Int, Str, Float, Range, Bool, Plugin, Metadata, Choices, MetadataColumn,
-    Numeric, Categorical, Citations, Visualization, TypeMatch, TypeMap)
+    Numeric, Categorical, Citations, Visualization, TypeMatch)
 from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Balance,
     PercentileNormalized)
@@ -437,10 +437,7 @@ plugin.visualizers.register_function(
                 'regressor.'
 )
 
-vmin_vmax, mask, __ = TypeMap({
-    (Float, Bool % Choices(False)): Visualization,
-    (Str % Choices('auto'), Bool): Visualization,
-})
+
 plugin.visualizers.register_function(
     function=confusion_matrix,
     inputs={'predictions': SampleData[ClassifierPredictions],
@@ -448,9 +445,8 @@ plugin.visualizers.register_function(
     parameters={
         'truth': MetadataColumn[Categorical],
         'missing_samples': parameters['base']['missing_samples'],
-        'vmin': vmin_vmax,
-        'vmax': vmin_vmax,
-        'mask': mask,
+        'vmin': Float | Str % Choices(['auto']),
+        'vmax': Float | Str % Choices(['auto']),
         'palette': Str % Choices(_custom_palettes().keys())},
     input_descriptions={
         'predictions': 'Predicted values to plot on x axis. Should be '

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -445,6 +445,8 @@ plugin.visualizers.register_function(
     parameters={
         'truth': MetadataColumn[Categorical],
         'missing_samples': parameters['base']['missing_samples'],
+        'vmin': Float | Str % Choices(['auto']),
+        'vmax': Float | Str % Choices(['auto']),
         'palette': Str % Choices(_custom_palettes().keys())},
     input_descriptions={
         'predictions': 'Predicted values to plot on x axis. Should be '
@@ -454,6 +456,8 @@ plugin.visualizers.register_function(
     parameter_descriptions={
         'truth': 'Metadata column (true values) to plot on y axis.',
         'missing_samples': parameter_descriptions['base']['missing_samples'],
+        'vmin': 'The minimum color value for the heatmap',
+        'vmax': 'The maximum color value for the heatmap',
         'palette': 'The color palette to use for plotting.'},
     name='Make a confusion matrix from sample classifier predictions.',
     description='Make a confusion matrix and calculate accuracy of predicted '

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1266,6 +1266,11 @@ class TestPlottingVisualizers(SampleClassifierTestPluginBase):
         with self.assertRaisesRegex(ValueError, "do not overlap"):
             confusion_matrix(self.tmpd, self.a, b)
 
+    def test_confusion_matrix_vmin_greater_vmax(self):
+        b = qiime2.CategoricalMetadataColumn(self.a)
+        with self.assertRaisesRegex(ValueError, 'vmin must be less than'):
+            confusion_matrix(self.tmpd, self.a, b, vmin=2, vmax=1)
+
     # test confusion matrix plotting independently to see how it handles
     # partially overlapping classes when true labels are superset
     def test_predict_and_plot_true_labels_are_superset(self):

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1268,22 +1268,21 @@ class TestPlottingVisualizers(SampleClassifierTestPluginBase):
 
     def test_confusion_matrix_vmin_too_high(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
-        with self.assertRaisesRegex(ValueError, 'vmin value must be less '
-                                    r'than.*\s\s0\.5.*greater.*0\.0'):
+        with self.assertRaisesRegex(ValueError, r'vmin must be less than.*\s\s'
+                                    r'0\.5.*greater.*0\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=None)
 
     def test_confusion_matrix_vmax_too_low(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
-        with self.assertRaisesRegex(ValueError, 'vmax value must be greater '
-                                    r'than.*\s\s0\.5.*less.*1\.0'):
+        with self.assertRaisesRegex(ValueError, r'vmax must be greater than.*'
+                                    r'\s\s0\.5.*less.*1\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=None, vmax=.5)
 
     def test_confusion_matrix_vmin_too_high_and_vmax_too_low(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
-        with self.assertRaisesRegex(ValueError, 'vmin value must be less '
-                                    r'than.*\s\s0\.5.*greater.*0\.0\s.*vmax '
-                                    r'value must be greater than.*\s\s0\.5.*'
-                                    r'less.*1\.0'):
+        with self.assertRaisesRegex(ValueError, r'vmin must be less than.*\s'
+                                    r'\s0\.5.*greater.*0\.0\s.*vmax must be '
+                                    r'greater than.*\s\s0\.5.*less.*1\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=.5)
 
     # test confusion matrix plotting independently to see how it handles

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1266,10 +1266,24 @@ class TestPlottingVisualizers(SampleClassifierTestPluginBase):
         with self.assertRaisesRegex(ValueError, "do not overlap"):
             confusion_matrix(self.tmpd, self.a, b)
 
-    def test_confusion_matrix_vmin_greater_vmax(self):
+    def test_confusion_matrix_vmin_too_high(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
-        with self.assertRaisesRegex(ValueError, 'vmin must be less than'):
-            confusion_matrix(self.tmpd, self.a, b, vmin=2, vmax=1)
+        with self.assertRaisesRegex(ValueError, 'vmin value must be less '
+                                    'than.*0.5.*greater.*0.0'):
+            confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=None)
+
+    def test_confusion_matrix_vmax_too_low(self):
+        b = qiime2.CategoricalMetadataColumn(self.a)
+        with self.assertRaisesRegex(ValueError, 'vmax value must be greater '
+                                    'than.*0.5.*less.*1.0'):
+            confusion_matrix(self.tmpd, self.a, b, vmin=None, vmax=.5)
+
+    def test_confusion_matrix_vmin_too_high_and_vmax_too_low(self):
+        b = qiime2.CategoricalMetadataColumn(self.a)
+        with self.assertRaisesRegex(ValueError, 'vmin value must be less '
+                                    'than.*0.5.*greater.*0.0.*vmax value must '
+                                    'be greater than.*0.5.*less.*1.0'):
+            confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=.5)
 
     # test confusion matrix plotting independently to see how it handles
     # partially overlapping classes when true labels are superset

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1269,20 +1269,21 @@ class TestPlottingVisualizers(SampleClassifierTestPluginBase):
     def test_confusion_matrix_vmin_too_high(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
         with self.assertRaisesRegex(ValueError, 'vmin value must be less '
-                                    'than.*0.5.*greater.*0.0'):
+                                    r'than.*\s\s0\.5.*greater.*0\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=None)
 
     def test_confusion_matrix_vmax_too_low(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
         with self.assertRaisesRegex(ValueError, 'vmax value must be greater '
-                                    'than.*0.5.*less.*1.0'):
+                                    r'than.*\s\s0\.5.*less.*1\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=None, vmax=.5)
 
     def test_confusion_matrix_vmin_too_high_and_vmax_too_low(self):
         b = qiime2.CategoricalMetadataColumn(self.a)
         with self.assertRaisesRegex(ValueError, 'vmin value must be less '
-                                    'than.*0.5.*greater.*0.0.*vmax value must '
-                                    'be greater than.*0.5.*less.*1.0'):
+                                    r'than.*\s\s0\.5.*greater.*0\.0\s.*vmax '
+                                    r'value must be greater than.*\s\s0\.5.*'
+                                    r'less.*1\.0'):
             confusion_matrix(self.tmpd, self.a, b, vmin=.5, vmax=.5)
 
     # test confusion matrix plotting independently to see how it handles

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -422,7 +422,7 @@ def _calculate_feature_importances(estimator):
 
 
 def _predict_and_plot(output_dir, y_test, y_pred, vmin=None, vmax=None,
-                      mask=False, classification=True, palette='sirocco'):
+                      classification=True, palette='sirocco'):
     if classification:
         x_classes = set(y_test.unique())
         y_classes = set(y_pred.unique())
@@ -434,7 +434,7 @@ def _predict_and_plot(output_dir, y_test, y_pred, vmin=None, vmax=None,
             classes = sorted(list(x_classes.union(y_classes)))
         predictions, predict_plot = _plot_confusion_matrix(
             y_test, y_pred, classes, normalize=True, palette=palette,
-            vmin=vmin, vmax=vmax, mask=False)
+            vmin=vmin, vmax=vmax)
     else:
         predictions = _linear_regress(y_test, y_pred)
         predict_plot = _regplot_from_dataframe(y_test, y_pred)
@@ -475,7 +475,7 @@ def _match_series_or_die(predictions, truth, missing_samples='error'):
 
 def _plot_accuracy(output_dir, predictions, truth, probabilities,
                    missing_samples, classification, palette, plot_title,
-                   vmin=None, vmax=None, mask=False):
+                   vmin=None, vmax=None):
     '''Plot accuracy results and send to visualizer on either categorical
     or numeric data inside two pd.Series
     '''
@@ -485,7 +485,7 @@ def _plot_accuracy(output_dir, predictions, truth, probabilities,
 
     # calculate prediction accuracy and plot results
     predictions, predict_plot = _predict_and_plot(
-        output_dir, truth, predictions, vmin=vmin, vmax=vmax, mask=False,
+        output_dir, truth, predictions, vmin=vmin, vmax=vmax,
         classification=classification, palette=palette)
 
     # optionally generate ROC curves for classification results

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -421,8 +421,8 @@ def _calculate_feature_importances(estimator):
     return importances
 
 
-def _predict_and_plot(output_dir, y_test, y_pred, classification=True,
-                      palette='sirocco'):
+def _predict_and_plot(output_dir, y_test, y_pred, vmin=None, vmax=None,
+                      classification=True, palette='sirocco'):
     if classification:
         x_classes = set(y_test.unique())
         y_classes = set(y_pred.unique())
@@ -433,7 +433,8 @@ def _predict_and_plot(output_dir, y_test, y_pred, classification=True,
         else:
             classes = sorted(list(x_classes.union(y_classes)))
         predictions, predict_plot = _plot_confusion_matrix(
-            y_test, y_pred, classes, normalize=True, palette=palette)
+            y_test, y_pred, classes, normalize=True, palette=palette,
+            vmin=vmin, vmax=vmax)
     else:
         predictions = _linear_regress(y_test, y_pred)
         predict_plot = _regplot_from_dataframe(y_test, y_pred)
@@ -473,7 +474,8 @@ def _match_series_or_die(predictions, truth, missing_samples='error'):
 
 
 def _plot_accuracy(output_dir, predictions, truth, probabilities,
-                   missing_samples, classification, palette, plot_title):
+                   missing_samples, classification, palette, plot_title,
+                   vmin=None, vmax=None):
     '''Plot accuracy results and send to visualizer on either categorical
     or numeric data inside two pd.Series
     '''
@@ -483,8 +485,8 @@ def _plot_accuracy(output_dir, predictions, truth, probabilities,
 
     # calculate prediction accuracy and plot results
     predictions, predict_plot = _predict_and_plot(
-        output_dir, truth, predictions, classification=classification,
-        palette=palette)
+        output_dir, truth, predictions, vmin=vmin, vmax=vmax,
+        classification=classification, palette=palette)
 
     # optionally generate ROC curves for classification results
     if probabilities is not None:

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -422,7 +422,7 @@ def _calculate_feature_importances(estimator):
 
 
 def _predict_and_plot(output_dir, y_test, y_pred, vmin=None, vmax=None,
-                      classification=True, palette='sirocco'):
+                      mask=False, classification=True, palette='sirocco'):
     if classification:
         x_classes = set(y_test.unique())
         y_classes = set(y_pred.unique())
@@ -434,7 +434,7 @@ def _predict_and_plot(output_dir, y_test, y_pred, vmin=None, vmax=None,
             classes = sorted(list(x_classes.union(y_classes)))
         predictions, predict_plot = _plot_confusion_matrix(
             y_test, y_pred, classes, normalize=True, palette=palette,
-            vmin=vmin, vmax=vmax)
+            vmin=vmin, vmax=vmax, mask=False)
     else:
         predictions = _linear_regress(y_test, y_pred)
         predict_plot = _regplot_from_dataframe(y_test, y_pred)
@@ -475,7 +475,7 @@ def _match_series_or_die(predictions, truth, missing_samples='error'):
 
 def _plot_accuracy(output_dir, predictions, truth, probabilities,
                    missing_samples, classification, palette, plot_title,
-                   vmin=None, vmax=None):
+                   vmin=None, vmax=None, mask=False):
     '''Plot accuracy results and send to visualizer on either categorical
     or numeric data inside two pd.Series
     '''
@@ -485,7 +485,7 @@ def _plot_accuracy(output_dir, predictions, truth, probabilities,
 
     # calculate prediction accuracy and plot results
     predictions, predict_plot = _predict_and_plot(
-        output_dir, truth, predictions, vmin=vmin, vmax=vmax,
+        output_dir, truth, predictions, vmin=vmin, vmax=vmax, mask=False,
         classification=classification, palette=palette)
 
     # optionally generate ROC curves for classification results

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -98,9 +98,10 @@ def _linear_regress(actual, pred):
         index=[actual.name])
 
 
-def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
+def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None,
+                                        mask=False):
     palette = _custom_palettes()[palette]
-    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
+    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette, mask=mask,
                        cbar_kws={'label': 'Proportion'})
 
 
@@ -111,7 +112,7 @@ def _add_sample_size_to_xtick_labels(ser, classes):
 
 
 def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
-                           vmin=None, vmax=None):
+                           vmin=None, vmax=None, mask=False):
 
     accuracy = accuracy_score(y_test, pd.DataFrame(y_pred))
     cm = confusion_matrix(y_test, y_pred)
@@ -124,7 +125,7 @@ def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
     cm = np.nan_to_num(cm)
 
     confusion = _plot_heatmap_from_confusion_matrix(cm, palette, vmin=vmin,
-                                                    vmax=vmax)
+                                                    vmax=vmax, mask=mask)
 
     x_tick_labels = _add_sample_size_to_xtick_labels(y_pred, classes)
     y_tick_labels = _add_sample_size_to_xtick_labels(y_test, classes)

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -100,26 +100,6 @@ def _linear_regress(actual, pred):
 
 def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
-
-    lowest_frequency = np.amin(cm)
-    highest_frequency = np.amax(cm)
-
-    error = ''
-    if vmin is not None:
-        if vmin > lowest_frequency:
-            error += ('Your vmin value must be less than or equal to the '
-                      'lowest prediction frequency present:\n'
-                      f'\t{vmin!r} is greater than {lowest_frequency!r}')
-    if vmax is not None:
-        if vmax < highest_frequency:
-            if error:
-                error += '\n'
-            error += ('Your vmax value must be greater than or equal to the '
-                      'highest prediction frequency present:\n'
-                      f'\t{vmax!r} is less than {highest_frequency!r}')
-    if error:
-        raise ValueError(error)
-
     return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
                        cbar_kws={'label': 'Proportion'})
 
@@ -142,6 +122,7 @@ def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
     # fill na values (e.g., true values that were not predicted) otherwise
     # these will appear as whitespace in plots and results table.
     cm = np.nan_to_num(cm)
+    _check_vmin_and_vmax(cm, vmin, vmax)
 
     confusion = _plot_heatmap_from_confusion_matrix(cm, palette, vmin=vmin,
                                                     vmax=vmax)
@@ -170,6 +151,27 @@ def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
     predictions.loc["Accuracy Ratio"]["Overall Accuracy"] = accuracy_ratio
 
     return predictions, confusion
+
+
+def _check_vmin_and_vmax(cm, vmin, vmax):
+    lowest_frequency = np.amin(cm)
+    highest_frequency = np.amax(cm)
+
+    error = ''
+    if vmin is not None:
+        if vmin > lowest_frequency:
+            error += ('Your vmin value must be less than or equal to the '
+                      'lowest prediction frequency present:\n'
+                      f'\t{vmin!r} is greater than {lowest_frequency!r}')
+    if vmax is not None:
+        if vmax < highest_frequency:
+            if error:
+                error += '\n'
+            error += ('Your vmax value must be greater than or equal to the '
+                      'highest prediction frequency present:\n'
+                      f'\t{vmax!r} is less than {highest_frequency!r}')
+    if error:
+        raise ValueError(error)
 
 
 def _calculate_baseline_accuracy(y_test, accuracy):

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -98,9 +98,10 @@ def _linear_regress(actual, pred):
         index=[actual.name])
 
 
-def _plot_heatmap_from_confusion_matrix(cm, palette):
+def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
-    return sns.heatmap(cm, cmap=palette, cbar_kws={'label': 'Proportion'})
+    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
+                       cbar_kws={'label': 'Proportion'})
 
 
 def _add_sample_size_to_xtick_labels(ser, classes):
@@ -109,7 +110,8 @@ def _add_sample_size_to_xtick_labels(ser, classes):
     return labels
 
 
-def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette):
+def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
+                           vmin=None, vmax=None):
 
     accuracy = accuracy_score(y_test, pd.DataFrame(y_pred))
     cm = confusion_matrix(y_test, y_pred)
@@ -121,7 +123,8 @@ def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette):
     # these will appear as whitespace in plots and results table.
     cm = np.nan_to_num(cm)
 
-    confusion = _plot_heatmap_from_confusion_matrix(cm, palette)
+    confusion = _plot_heatmap_from_confusion_matrix(cm, palette, vmin=vmin,
+                                                    vmax=vmax)
 
     x_tick_labels = _add_sample_size_to_xtick_labels(y_pred, classes)
     y_tick_labels = _add_sample_size_to_xtick_labels(y_test, classes)

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -98,10 +98,29 @@ def _linear_regress(actual, pred):
         index=[actual.name])
 
 
-def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None,
-                                        mask=False):
+def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
-    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette, mask=mask,
+
+    lowest_frequency = np.amin(cm)
+    highest_frequency = np.amax(cm)
+
+    error = ''
+    if vmin is not None:
+        if vmin > lowest_frequency:
+            error += ('Your vmin value must be less than or equal to the '
+                      'lowest prediction frequency present:\n'
+                      f'\t{vmin!r} is greater than {lowest_frequency!r}')
+    if vmax is not None:
+        if vmax < highest_frequency:
+            if error:
+                error += '\n'
+            error += ('Your vmax value must be greater than or equal to the '
+                      'highest prediction frequency present:\n'
+                      f'\t{vmax!r} is less than {highest_frequency!r}')
+    if error:
+        raise ValueError(error)
+
+    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
                        cbar_kws={'label': 'Proportion'})
 
 
@@ -112,7 +131,7 @@ def _add_sample_size_to_xtick_labels(ser, classes):
 
 
 def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
-                           vmin=None, vmax=None, mask=False):
+                           vmin=None, vmax=None):
 
     accuracy = accuracy_score(y_test, pd.DataFrame(y_pred))
     cm = confusion_matrix(y_test, y_pred)
@@ -125,7 +144,7 @@ def _plot_confusion_matrix(y_test, y_pred, classes, normalize, palette,
     cm = np.nan_to_num(cm)
 
     confusion = _plot_heatmap_from_confusion_matrix(cm, palette, vmin=vmin,
-                                                    vmax=vmax, mask=mask)
+                                                    vmax=vmax)
 
     x_tick_labels = _add_sample_size_to_xtick_labels(y_pred, classes)
     y_tick_labels = _add_sample_size_to_xtick_labels(y_test, classes)

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -160,15 +160,15 @@ def _check_vmin_and_vmax(cm, vmin, vmax):
     error = ''
     if vmin is not None:
         if vmin > lowest_frequency:
-            error += ('Your vmin value must be less than or equal to the '
-                      'lowest prediction frequency present:\n'
+            error += ('vmin must be less than or equal to the lowest '
+                      'predicted class frequency:\n'
                       f'\t{vmin!r} is greater than {lowest_frequency!r}')
     if vmax is not None:
         if vmax < highest_frequency:
             if error:
                 error += '\n'
-            error += ('Your vmax value must be greater than or equal to the '
-                      'highest prediction frequency present:\n'
+            error += ('vmax must be greater than or equal to the highest '
+                      'predicted class frequency:\n'
                       f'\t{vmax!r} is less than {highest_frequency!r}')
     if error:
         raise ValueError(error)


### PR DESCRIPTION
Closes #148 Adds ability to adjust colorscale of heatmaps derived from confusion matrices via seaborn's vmin and vmax parameters. Is this along the lines of what you want @nbokulich? Once the parameters are properly implemented I can add some tests.