### PR TITLE
added drop_all_unique param

### DIFF
--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -48,10 +48,6 @@ def metatable(ctx,
     metadata = metadata.filter_columns(
         column_type='numeric', drop_all_unique=drop_all_unique,
         drop_zero_variance=True, drop_all_missing=True).to_dataframe()
-    # drop columns with negative values
-    # pd.DataFrame.any() reverses the normal axis definition: axis=0 reduces
-    # the index, return a Series whose index is the original column labels.
-    metadata = metadata.loc[:, -(metadata < 0).any(axis=0)]
 
     if missing_values == 'drop_samples':
         metadata = metadata.dropna(axis=0)
@@ -65,6 +61,10 @@ def metatable(ctx,
                          'to review your options.')
     elif missing_values == 'fill':
         metadata = metadata.fillna(0.)
+
+    # drop columns with negative values
+    # grab column IDs with all values >= 0
+    metadata = metadata.loc[:, (metadata >= 0).all(axis=0)]
 
     if len(metadata.columns) == 0:
         raise ValueError('All metadata columns have been filtered.')

--- a/q2_sample_classifier/classify.py
+++ b/q2_sample_classifier/classify.py
@@ -42,13 +42,16 @@ def metatable(ctx,
               metadata,
               table=None,
               missing_samples='ignore',
-              missing_values='error'):
+              missing_values='error',
+              drop_all_unique=False):
     # gather numeric metadata
     metadata = metadata.filter_columns(
-        column_type='numeric', drop_all_unique=True, drop_zero_variance=True,
-        drop_all_missing=True).to_dataframe()
+        column_type='numeric', drop_all_unique=drop_all_unique,
+        drop_zero_variance=True, drop_all_missing=True).to_dataframe()
     # drop columns with negative values
-    metadata = metadata[-(metadata < 0).any(axis=1)]
+    # pd.DataFrame.any() reverses the normal axis definition: axis=0 reduces
+    # the index, return a Series whose index is the original column labels.
+    metadata = metadata.loc[:, -(metadata < 0).any(axis=0)]
 
     if missing_values == 'drop_samples':
         metadata = metadata.dropna(axis=0)

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -519,7 +519,8 @@ plugin.pipelines.register_function(
     parameters={'metadata': Metadata,
                 'missing_samples': parameters['base']['missing_samples'],
                 'missing_values': Str % Choices(
-                    ['drop_samples', 'drop_features', 'error', 'fill'])},
+                    ['drop_samples', 'drop_features', 'error', 'fill']),
+                'drop_all_unique': Bool},
     outputs=[('converted_table', FeatureTable[Frequency])],
     input_descriptions={'table': input_descriptions['table']},
     parameter_descriptions={
@@ -529,7 +530,9 @@ plugin.pipelines.register_function(
             'How to handle missing values (nans) in metadata. Either '
             '"drop_samples" with missing values, "drop_features" with missing '
             'values, "fill" missing values with zeros, or "error" if '
-            'any missing values are found.')
+            'any missing values are found.'),
+        'drop_all_unique': 'If True, columns that contain a unique value for '
+                           'every ID will be dropped.'
     },
     output_descriptions={'converted_table': 'Converted feature table'},
     name='Convert (and merge) positive numeric metadata (in)to feature table.',
@@ -543,7 +546,7 @@ plugin.pipelines.register_function(
                 'found in the table are missing from the metadata file. The '
                 'metadata file can always contain a superset of samples. Note '
                 'that columns will be dropped if they are non-numeric, '
-                'contain only unique values, contain no unique values (zero '
+                'contain no unique values (zero '
                 'variance), contain only empty cells, or contain negative '
                 'values. This method currently only converts '
                 'postive numeric metadata into feature data. Tip: convert '

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1147,7 +1147,7 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
 
     def test_metatable_missing_error(self):
         with self.assertRaisesRegex(ValueError, "missing values"):
-            print(sample_classifier.actions.metatable(
+            (sample_classifier.actions.metatable(
                 self.md2, missing_values='error').view(pd.DataFrame))
 
     def test_metatable_drop_samples(self):

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1148,7 +1148,7 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
     def test_metatable_missing_error(self):
         with self.assertRaisesRegex(ValueError, "missing values"):
             sample_classifier.actions.metatable(
-                self.md2, missing_values='error').view(pd.DataFrame)
+                self.md2, missing_values='error')
 
     def test_metatable_drop_samples(self):
         exp = biom.Table(

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1147,8 +1147,8 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
 
     def test_metatable_missing_error(self):
         with self.assertRaisesRegex(ValueError, "missing values"):
-            (sample_classifier.actions.metatable(
-                self.md2, missing_values='error').view(pd.DataFrame))
+            sample_classifier.actions.metatable(
+                self.md2, missing_values='error').view(pd.DataFrame)
 
     def test_metatable_drop_samples(self):
         exp = biom.Table(

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -1147,8 +1147,8 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
 
     def test_metatable_missing_error(self):
         with self.assertRaisesRegex(ValueError, "missing values"):
-            sample_classifier.actions.metatable(
-                self.md2, missing_values='error')
+            print(sample_classifier.actions.metatable(
+                self.md2, missing_values='error').view(pd.DataFrame))
 
     def test_metatable_drop_samples(self):
         exp = biom.Table(
@@ -1212,12 +1212,12 @@ class NowLetsTestTheActions(SampleClassifierTestPluginBase):
                 self.tab, missing_samples='error',
                 missing_values='drop_samples')
 
-    def test_metatable_empty_metadata_after_filtering(self):
+    def test_metatable_empty_metadata_after_drop_all_unique(self):
         with self.assertRaisesRegex(
                 ValueError, "All metadata"):  # are belong to us
             sample_classifier.actions.metatable(
                 self.md2.filter_ids(['b', 'c']), self.tab,
-                missing_values='drop_samples')
+                missing_values='drop_samples', drop_all_unique=True)
 
     def test_metatable_no_samples_after_filtering(self):
         junk_md = pd.DataFrame(


### PR DESCRIPTION
fixes #173 

While fixing #173 (adding drop_all_unique param), I also discovered that dropping negative values was acting on the wrong axis. It had not been detected by unit tests previously because the `drop_all_unique` was dropping the negative values in the test data already. I fixed the code and tweaked two tests to ensure that 1) negative filtering and 2) `drop_all_unique` are working as intended.