### PR TITLE
MAINT: removed use of deprecated method from_csv

### DIFF
--- a/q2_sample_classifier/_transformer.py
+++ b/q2_sample_classifier/_transformer.py
@@ -102,7 +102,7 @@ def _9(ff: ImportanceFormat) -> (qiime2.Metadata):
 def _10(data: pd.DataFrame) -> (ProbabilitiesFormat):
     ff = ProbabilitiesFormat()
     with ff.open() as fh:
-        data.to_csv(fh, sep='\t', header=True, na_rep=np.nan)
+        data.to_csv(fh, sep='\t', na_rep=np.nan, header=True)
     return ff
 
 

--- a/q2_sample_classifier/tests/test_classifier.py
+++ b/q2_sample_classifier/tests/test_classifier.py
@@ -543,7 +543,8 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
                            columns=['classA', 'classB'],
                            index=['a', 'b', 'c', 'd'])
         obs = transformer(exp)
-        obs = pd.DataFrame.from_csv(str(obs), sep='\t', header=0)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0,
+                          parse_dates=True)
         pdt.assert_frame_equal(exp, obs)
 
     def test_Probabilities_format_to_pd_dataframe(self):


### PR DESCRIPTION
Pandas has deprecated the from_csv method in favor of read_csv as of v0.21.0. This change is needed to make plugins pass unit tests utilizing the newest version of pandas v0.25.1. Fixes issue #176 
