### PR TITLE
Showing yticks complete, this closes #143

### DIFF
--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -102,7 +102,8 @@ def _linear_regress(actual, pred):
 def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
     return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
-                       cbar_kws={'label': 'Proportion'})
+                       cbar_kws={'label': 'Proportion'}, 
+                       xticklabels=True, yticklabels=True)
 
 
 def _add_sample_size_to_xtick_labels(ser, classes):

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -102,7 +102,7 @@ def _linear_regress(actual, pred):
 def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
     return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
-                       cbar_kws={'label': 'Proportion'}, 
+                       cbar_kws={'label': 'Proportion'},
                        xticklabels=True, yticklabels=True)
 
 


### PR DESCRIPTION
Referring to #143 this solves not showing all the labels in the y axis. 

**Before:** 
![test-1](https://user-images.githubusercontent.com/20823315/66428190-3488c900-e9db-11e9-88b9-5315a5b51c5a.png)

**After:**

![Test](https://user-images.githubusercontent.com/20823315/66428195-36528c80-e9db-11e9-8e97-ab0833c2bec9.png)
