### PR TITLE
BUG: heatmap now displays all classes properly, resizes dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,8 @@ target/
 
 # other
 *~
+*.code-workspace
+.vscode/
+
 
 .DS_store

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -102,7 +102,7 @@ def _linear_regress(actual, pred):
 def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
     plt.figure()
-    scaletron, labelsize, dpi = 20, 8, 100
+    scaler, labelsize, dpi, cbar_min = 20, 8, 100, .15
     sns.set(rc={'xtick.labelsize': labelsize, 'ytick.labelsize': labelsize,
             'figure.dpi': dpi})
     fig, (ax, cax) = plt.subplots(ncols=2, constrained_layout=True)
@@ -112,9 +112,9 @@ def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
 
     # Resize the plot dynamically based on number of classes
     hm_pos = ax.get_position()
-    scale = len(cm) / scaletron
-    # set minimum color bar height for readability
-    cbar_height = scale if (scale >= .15) else .15
+    scale = len(cm) / scaler
+    # prevent cbar from getting unreadably small
+    cbar_height = max(cbar_min, scale)
     ax.set_position([hm_pos.x0, hm_pos.y0, scale, scale])
     cax.set_position([hm_pos.x0 + scale * .95, hm_pos.y0, scale / len(cm),
                      cbar_height])

--- a/q2_sample_classifier/visuals.py
+++ b/q2_sample_classifier/visuals.py
@@ -101,8 +101,27 @@ def _linear_regress(actual, pred):
 
 def _plot_heatmap_from_confusion_matrix(cm, palette, vmin=None, vmax=None):
     palette = _custom_palettes()[palette]
-    return sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette,
-                       cbar_kws={'label': 'Proportion'})
+    scaletron, labelsize, dpi = 20, 8, 100
+    sns.set(rc={'xtick.labelsize': labelsize, 'ytick.labelsize': labelsize,
+            'figure.dpi': dpi})
+    fig, (ax, cax) = plt.subplots(ncols=2, constrained_layout=True)
+    heatmap = sns.heatmap(cm, vmin=vmin, vmax=vmax, cmap=palette, ax=ax,
+                          cbar_ax=cax, cbar_kws={'label': 'Proportion'},
+                          square=True, xticklabels=True, yticklabels=True)
+
+    # Resize the plot dynamically based on number of classes
+    hm_pos = ax.get_position()
+    scale = len(cm) / scaletron
+    # set minimum color bar height for readability
+    cbar_height = scale if (scale >= .15) else .15
+    ax.set_position([hm_pos.x0, hm_pos.y0, scale, scale])
+    cax.set_position([hm_pos.x0 + scale * .95, hm_pos.y0, scale / len(cm),
+                     cbar_height])
+
+    # Make the heatmap subplot (not the colorbar) the active axis object so
+    # labels apply correctly on return
+    plt.sca(ax)
+    return heatmap
 
 
 def _add_sample_size_to_xtick_labels(ser, classes):


### PR DESCRIPTION
closes #143 , supersedes https://github.com/qiime2/q2-sample-classifier/pull/180
Thanks, @danteese for helping kick this off! Hopefully, this PR finishes what you started. :slightly_smiling_face: 
Thanks @Oddant1 for wallowing in the matplotlib docs with me.

These changes allow `heatmap` to render a heatmap of an arbitrary number of classes, displaying all classes as labels, preserving a 1:1 aspect for heatmap cells, and resizing the plot dynamically to accommodate. 

---

**Questions:** 
1. Cell size - Is this a good size for the boxes/cells that make up the heatmap itself? Do they need upsizing or downsizing? Screencaps attached below, at tiny, medium, and very large.
2. Borders - We don't outline many of our plots. I assume we want to stick with that here? I've mocked an outlined one as well, in case you like. LMK
3. Proportion bar readability - take a look at the color bar in the _tiny_ size. Is that readable enough? Do we want to make it taller for tiny-size plots? (In larger plots, it scales 1:1 with the heatmap itself. )
4. Code organization - The method modified here persists in building this plot, and _not_ labeling it. Labelling happens in the calling function, `_plot_confusion_matrix`. The references to the heatmap and colorbar axes created in this diff are not passed back to the calling function, so colorbar and its attributes remain un-editable there. I don't feel this is a major loss, but the separation of the two parts of the process feels a little weird to me. Handling both the plot build and labelling in one function would mitigate this, but would require us to pass more data around. I'm inclined to keep things as is, unless someone feels re-organization would bring us maintainability or stability in the future. What do you think?

---

**Samples:** 
Tiny: 
[hm_tiny.pdf](https://github.com/qiime2/q2-sample-classifier/files/3881968/hm_tiny.pdf)

Big: 
[hm_big.pdf](https://github.com/qiime2/q2-sample-classifier/files/3881969/hm_big.pdf)

Huge:
[hm_huge.pdf](https://github.com/qiime2/q2-sample-classifier/files/3881970/hm_huge.pdf)

Bordered Big:
[hm_bordered.pdf](https://github.com/qiime2/q2-sample-classifier/files/3881971/hm_bordered.pdf)



