### PR TITLE
Pin scikit-learn to same version as feature-classifier

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pandas
     - scipy
     - joblib
-    - scikit-learn
+    - scikit-learn 0.21.2
     - scikit-bio
     - seaborn >=0.8
     - fastcluster


### PR DESCRIPTION
This pin it to help determine issues for the current build prior to the release. 
