### PR TITLE
ENH: `summarize` should provide link to download raw data from RFE plots

### DIFF
--- a/q2_sample_classifier/assets/index.html
+++ b/q2_sample_classifier/assets/index.html
@@ -67,6 +67,11 @@
       </a>
     </div>
     {% endif %}
+    {% if rfe %}
+    <a href="rfe_scores.tsv">
+      <p>Download rfe scores as tsv</p>
+    </a>
+    {% endif %}
     {% if result %}
     <h1>Model parameters</h1>
     <div class="col-lg-12">

--- a/q2_sample_classifier/assets/index.html
+++ b/q2_sample_classifier/assets/index.html
@@ -65,12 +65,10 @@
         <br>
         <p>Download as PDF</p>
       </a>
+      <a href="rfe_scores.tsv">
+        <p>Download rfe scores as tsv</p>
+      </a>
     </div>
-    {% endif %}
-    {% if rfe %}
-    <a href="rfe_scores.tsv">
-      <p>Download rfe scores as tsv</p>
-    </a>
     {% endif %}
     {% if result %}
     <h1>Model parameters</h1>

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -528,7 +528,6 @@ def _summarize_estimator(output_dir, sample_estimator):
                           index=sample_estimator.rfe_scores.index)
         df.index.name = 'feature_count'
         df.to_csv(join(output_dir, 'rfe_scores.tsv'), sep='\t', index=True)
-        
     # if the rfe_scores attribute does not exist, do nothing
     except AttributeError:
         optimize_feature_selection = False

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -523,6 +523,12 @@ def _summarize_estimator(output_dir, sample_estimator):
         rfep.savefig(join(output_dir, 'rfe_plot.pdf'))
         plt.close('all')
         optimize_feature_selection = True
+        # generate rfe scores file
+        df = pd.DataFrame(data={'rfe_score': sample_estimator.rfe_scores},
+                          index=sample_estimator.rfe_scores.index)
+        df.index.name = 'feature_count'
+        df.to_csv(join(output_dir, 'rfe_scores.tsv'), sep='\t', index=True)
+        
     # if the rfe_scores attribute does not exist, do nothing
     except AttributeError:
         optimize_feature_selection = False


### PR DESCRIPTION
Fixes #184 
Generate a RFE scores file (accuracy and feature count) and create a link to download it.

<img width="1153" alt="Screen Shot 2021-03-06 at 7 10 05 PM" src="https://user-images.githubusercontent.com/30737103/110225925-f9b6f780-7f24-11eb-80f9-acf7d9bd16f0.png">