### PR TITLE
ENH: add cross-validation to KNN with DistanceMatrix

### DIFF
--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -255,6 +255,9 @@ plugin.pipelines.register_function(
     parameters={
         'metadata': MetadataColumn[Categorical],
         'k': Int,
+        'cv': parameters['cv']['cv'],
+        'random_state': parameters['base']['random_state'],
+        'n_jobs': parameters['base']['n_jobs'],
         'palette': Str % Choices(_custom_palettes().keys()),
     },
     outputs=[
@@ -265,6 +268,9 @@ plugin.pipelines.register_function(
     parameter_descriptions={
         'metadata': 'Categorical metadata column to use as prediction target.',
         'k': 'Number of nearest neighbors',
+        'cv': parameter_descriptions['cv']['cv'],
+        'random_state': parameter_descriptions['base']['random_state'],
+        'n_jobs': parameter_descriptions['base']['n_jobs'],
         'palette': 'The color palette to use for plotting.',
     },
     output_descriptions={

--- a/q2_sample_classifier/tests/test_estimators.py
+++ b/q2_sample_classifier/tests/test_estimators.py
@@ -162,7 +162,8 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
 
         # -- test -- #
         res = sample_classifier.actions.classify_samples_from_dist(
-            distance_matrix=dm, metadata=metadata, k=1)
+            distance_matrix=dm, metadata=metadata, k=1, cv=3, random_state=123
+        )
         pred = res[0].view(pd.Series).sort_values()
         expected = pd.Series(('fat', 'skinny', 'fat', 'skinny'),
                              index=['f1', 's1', 'f2', 's2'])
@@ -192,7 +193,8 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
 
         # -- test -- #
         res = sample_classifier.actions.classify_samples_from_dist(
-            distance_matrix=dm, metadata=metadata, k=1)
+            distance_matrix=dm, metadata=metadata, k=1, cv=3, random_state=123
+        )
         pred = res[0].view(pd.Series)
         expected = pd.Series(('skinny', 'skinny', 'skinny', 'skinny'),
                              index=sample_ids)
@@ -222,7 +224,8 @@ class EstimatorsTests(SampleClassifierTestPluginBase):
 
         # -- test -- #
         res = sample_classifier.actions.classify_samples_from_dist(
-            distance_matrix=dm, metadata=metadata, k=2)
+            distance_matrix=dm, metadata=metadata, k=2, cv=3, random_state=123
+        )
         pred = res[0].view(pd.Series)
         expected = pd.Series(('skinny', 'fat', 'fat', 'skinny'),
                              index=sample_ids)


### PR DESCRIPTION
This PR rewrites slightly the `classify_samples_from_dist` to:
- introduce cross-validation
- replace the custom KNN implementation with the sklearn one for consistency.

The final confusion matrix is generated by collecting test samples from all the folds and comparing those to the ground truth.
