### PR TITLE
replace deprecated `grid_scores_` attribute

### DIFF
--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -248,12 +248,12 @@ def _extract_rfe_scores(rfecv):
     # If using fractional step, step = integer of fraction * n_features
     if rfecv.step < 1:
         rfecv.step = int(rfecv.step * n_features)
-    # Need to manually calculate x-axis, as rfecv.grid_scores_ are a 1-d array
+    # Need to manually calculate x-axis, as rfecv.cv_results_['mean_test_score'] are a 1-d array
     x = [n_features - (n * rfecv.step)
-         for n in range(len(rfecv.grid_scores_)-1, -1, -1)]
+         for n in range(len(rfecv.cv_results_['mean_test_score'])-1, -1, -1)]
     if x[0] < 1:
         x[0] = 1
-    return pd.Series(rfecv.grid_scores_, index=x, name='Accuracy')
+    return pd.Series(rfecv.cv_results_['mean_test_score'], index=x, name='Accuracy')
 
 
 def nested_cross_validation(table, metadata, cv, random_state, n_jobs,

--- a/q2_sample_classifier/utilities.py
+++ b/q2_sample_classifier/utilities.py
@@ -248,12 +248,14 @@ def _extract_rfe_scores(rfecv):
     # If using fractional step, step = integer of fraction * n_features
     if rfecv.step < 1:
         rfecv.step = int(rfecv.step * n_features)
-    # Need to manually calculate x-axis, as rfecv.cv_results_['mean_test_score'] are a 1-d array
+    # Need to manually calculate x-axis, as
+    # rfecv.cv_results_['mean_test_score'] are a 1-d array
     x = [n_features - (n * rfecv.step)
          for n in range(len(rfecv.cv_results_['mean_test_score'])-1, -1, -1)]
     if x[0] < 1:
         x[0] = 1
-    return pd.Series(rfecv.cv_results_['mean_test_score'], index=x, name='Accuracy')
+    return pd.Series(rfecv.cv_results_['mean_test_score'],
+                     index=x, name='Accuracy')
 
 
 def nested_cross_validation(table, metadata, cv, random_state, n_jobs,


### PR DESCRIPTION
`grid_scores_` attribute is [deprecated](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.RFECV.html#sklearn.feature_selection.RFECV.grid_scores_) and will be removed in sklearn 1.2 .

This PR proposes to use the preferred `cv_results_` in favour