### PR TITLE
Prepare versioneer.py for Python 3.12.

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -340,9 +340,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
As seen first in [Debian bug #1058220], execution of the versioneer.py script fails with Python 3.12 with the following error:

	Traceback (most recent call last):
	  File "/<<PKGBUILDDIR>>/setup.py", line 16, in <module>
	    version=versioneer.get_version(),
	            ^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/<<PKGBUILDDIR>>/versioneer.py", line 1481, in get_version
	    return get_versions()["version"]
	           ^^^^^^^^^^^^^^
	  File "/<<PKGBUILDDIR>>/versioneer.py", line 1413, in get_versions
	    cfg = get_config_from_root(root)
	          ^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/<<PKGBUILDDIR>>/versioneer.py", line 343, in get_config_from_root
	    parser = configparser.SafeConfigParser()
	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?

This patch follows [Python 3.12 configparser porting guidelines] to resolve this issue.

[Debian bug #1058220]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058220
[Python 3.12 configparser porting guidelines]: https://docs.python.org/3/whatsnew/3.12.html#configparser
