### PR TITLE
ENH: accept additional featuretable types

### DIFF
--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -13,7 +13,7 @@ from qiime2.plugin import (
     Numeric, Categorical, Citations, Visualization, TypeMatch)
 from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Balance,
-    PercentileNormalized, Design)
+    PercentileNormalized, Design, Composition)
 from q2_types.sample_data import SampleData
 from q2_types.feature_data import FeatureData
 from q2_types.distance_matrix import DistanceMatrix
@@ -89,7 +89,8 @@ predict_description = (
     'contain overlapping features with the feature table used to train '
     'the estimator.')
 
-inputs = {'table': FeatureTable[Frequency]}
+inputs = {'table': FeatureTable[
+    Frequency | RelativeFrequency | PresenceAbsence | Composition]}
 
 input_descriptions = {'table': 'Feature table containing all features that '
                                'should be used for target prediction.',
@@ -492,7 +493,7 @@ plugin.visualizers.register_function(
 
 
 T = TypeMatch([Frequency, RelativeFrequency, PresenceAbsence, Balance,
-               PercentileNormalized, Design])
+               PercentileNormalized, Design, Composition])
 plugin.methods.register_function(
     function=split_table,
     inputs={'table': FeatureTable[T]},


### PR DESCRIPTION
fixes #230 

Adds additional feature table types to the acceptable inputs for various classification and regression methods. For now I have only added types that have non-negative values or at least have descriptions to clarify what these contain (i.e., not balance or percentile abundance).

**Question**: would you like to see unit tests for each type? I checked out q2-feature-table for precedent, where it looks like different types are not tested for actions that accept multiple types. As the internal format is identical for these types, any tests would be redundant. So for now I have not added tests so we can discuss first.