### PR TITLE
Revert "MAINT: move Importance formats and type to q2-types (#246)"

### DIFF
--- a/q2_sample_classifier/__init__.py
+++ b/q2_sample_classifier/__init__.py
@@ -8,12 +8,13 @@
 
 from ._format import (
     BooleanSeriesFormat, BooleanSeriesDirectoryFormat,
-    PredictionsFormat, PredictionsDirectoryFormat, SampleEstimatorDirFmt,
-    PickleFormat, ProbabilitiesFormat, ProbabilitiesDirectoryFormat,
+    PredictionsFormat, PredictionsDirectoryFormat, ImportanceFormat,
+    ImportanceDirectoryFormat, SampleEstimatorDirFmt, PickleFormat,
+    ProbabilitiesFormat, ProbabilitiesDirectoryFormat,
     TrueTargetsDirectoryFormat)
 from ._type import (BooleanSeries, ClassifierPredictions, RegressorPredictions,
-                    SampleEstimator, Classifier, Regressor, Probabilities,
-                    TrueTargets)
+                    Importance, SampleEstimator, Classifier, Regressor,
+                    Probabilities, TrueTargets)
 
 
 try:
@@ -23,8 +24,9 @@ except ModuleNotFoundError:
 
 __all__ = ['BooleanSeriesFormat', 'BooleanSeriesDirectoryFormat',
            'PredictionsFormat', 'PredictionsDirectoryFormat',
+           'ImportanceFormat', 'ImportanceDirectoryFormat',
            'SampleEstimatorDirFmt', 'PickleFormat', 'BooleanSeries',
-           'ClassifierPredictions', 'RegressorPredictions',
+           'ClassifierPredictions', 'RegressorPredictions', 'Importance',
            'Classifier', 'Regressor', 'SampleEstimator', 'Probabilities',
            'ProbabilitiesFormat', 'ProbabilitiesDirectoryFormat',
            'TrueTargets', 'TrueTargetsDirectoryFormat']

--- a/q2_sample_classifier/_format.py
+++ b/q2_sample_classifier/_format.py
@@ -120,25 +120,27 @@ PredictionsDirectoryFormat = model.SingleFileDirectoryFormat(
     PredictionsFormat)
 
 
-class ProbabilitiesFormat(model.TextFileFormat):
+class _MultiColumnNumericFormat(model.TextFileFormat):
     def _validate(self, n_records=None):
-        """Validate rows with an identifier followed by numeric values."""
         with self.open() as fh:
-            # The header is intentionally flexible because column names and
-            # counts can vary by estimator.
-            fh.readline()
+            # validate header
+            # for now we will not validate any information in the header,
+            # since column names, count etc are frequently unique to individual
+            # estimators. Let's keep this flexible.
+            line = fh.readline()
 
+            # validate body
             has_data = False
             for line_number, line in enumerate(fh, start=2):
-                # Strip each cell rather than the full line so empty cells are
-                # preserved and fail numeric validation.
+                # we want to strip each cell, not the original line
+                # otherwise empty cells are dropped, causing a TypeError
                 cells = [c.strip() for c in line.split('\t')]
                 if len(cells) < 2:
                     raise ValidationError(
                         "Expected data record to be TSV with two or more "
                         "fields. Detected {0} fields at line {1}:\n\n{2!r}"
                         .format(len(cells), line_number, cells))
-
+                # all values (except row name) should be numbers
                 try:
                     [float(c) for c in cells[1:]]
                 except ValueError:
@@ -154,9 +156,21 @@ class ProbabilitiesFormat(model.TextFileFormat):
             _validate_file_not_empty(has_data)
 
     def _validate_(self, level):
-        """Validate this format using QIIME 2's min or max validation level."""
         record_count_map = {'min': 5, 'max': None}
         self._validate(record_count_map[level])
+
+
+class ImportanceFormat(_MultiColumnNumericFormat):
+    pass
+
+
+ImportanceDirectoryFormat = model.SingleFileDirectoryFormat(
+    'ImportanceDirectoryFormat', 'importance.tsv',
+    ImportanceFormat)
+
+
+class ProbabilitiesFormat(_MultiColumnNumericFormat):
+    pass
 
 
 ProbabilitiesDirectoryFormat = model.SingleFileDirectoryFormat(

--- a/q2_sample_classifier/_transformer.py
+++ b/q2_sample_classifier/_transformer.py
@@ -20,7 +20,8 @@ from sklearn.pipeline import Pipeline
 
 from .plugin_setup import plugin
 from ._format import (SampleEstimatorDirFmt, JSONFormat, BooleanSeriesFormat,
-                      PredictionsFormat, PickleFormat, ProbabilitiesFormat)
+                      ImportanceFormat, PredictionsFormat, PickleFormat,
+                      ProbabilitiesFormat)
 
 
 def _read_dataframe(fh):
@@ -73,6 +74,28 @@ def _6(ff: PredictionsFormat) -> (qiime2.Metadata):
     with ff.open() as fh:
         return qiime2.Metadata(_read_dataframe(fh).apply(
             lambda x: pd.to_numeric(x, errors='ignore')))
+
+
+@plugin.register_transformer
+def _7(data: pd.DataFrame) -> (ImportanceFormat):
+    ff = ImportanceFormat()
+    with ff.open() as fh:
+        data.to_csv(fh, sep='\t', header=True, na_rep=np.nan)
+    return ff
+
+
+@plugin.register_transformer
+def _8(ff: ImportanceFormat) -> (pd.DataFrame):
+    with ff.open() as fh:
+        return _read_dataframe(fh).apply(
+            lambda x: pd.to_numeric(x, errors='raise'))
+
+
+@plugin.register_transformer
+def _9(ff: ImportanceFormat) -> (qiime2.Metadata):
+    with ff.open() as fh:
+        return qiime2.Metadata(_read_dataframe(fh).apply(
+            lambda x: pd.to_numeric(x, errors='raise')))
 
 
 @plugin.register_transformer

--- a/q2_sample_classifier/_type.py
+++ b/q2_sample_classifier/_type.py
@@ -8,6 +8,7 @@
 
 from qiime2.plugin import SemanticType
 from q2_types.sample_data import SampleData
+from q2_types.feature_data import FeatureData
 
 
 ClassifierPredictions = SemanticType(
@@ -21,6 +22,8 @@ Regressor = SemanticType(
     'Regressor', variant_of=SampleEstimator.field['type'])
 BooleanSeries = SemanticType(
     'BooleanSeries', variant_of=SampleData.field['type'])
+Importance = SemanticType(
+    'Importance', variant_of=FeatureData.field['type'])
 Probabilities = SemanticType(
     'Probabilities', variant_of=SampleData.field['type'])
 TrueTargets = SemanticType(

--- a/q2_sample_classifier/plugin_setup.py
+++ b/q2_sample_classifier/plugin_setup.py
@@ -28,6 +28,8 @@ from .visuals import _custom_palettes
 from ._format import (SampleEstimatorDirFmt,
                       BooleanSeriesFormat,
                       BooleanSeriesDirectoryFormat,
+                      ImportanceFormat,
+                      ImportanceDirectoryFormat,
                       PredictionsFormat,
                       PredictionsDirectoryFormat,
                       ProbabilitiesFormat,
@@ -35,9 +37,9 @@ from ._format import (SampleEstimatorDirFmt,
                       TrueTargetsDirectoryFormat)
 
 from ._type import (ClassifierPredictions, RegressorPredictions,
-                    SampleEstimator, BooleanSeries, Classifier, Regressor,
-                    Probabilities, TrueTargets)
-from q2_types.feature_data import Importance
+                    SampleEstimator, BooleanSeries, Importance,
+                    Classifier, Regressor, Probabilities,
+                    TrueTargets)
 import q2_sample_classifier
 
 citations = Citations.load('citations.bib', package='q2_sample_classifier')
@@ -644,7 +646,7 @@ plugin.pipelines.register_function(
 
 # Registrations
 plugin.register_semantic_types(
-    SampleEstimator, BooleanSeries, ClassifierPredictions,
+    SampleEstimator, BooleanSeries, Importance, ClassifierPredictions,
     RegressorPredictions, Classifier, Regressor, Probabilities, TrueTargets)
 plugin.register_semantic_type_to_format(
     SampleEstimator[Classifier],
@@ -662,6 +664,9 @@ plugin.register_semantic_type_to_format(
     SampleData[ClassifierPredictions],
     artifact_format=PredictionsDirectoryFormat)
 plugin.register_semantic_type_to_format(
+    FeatureData[Importance],
+    artifact_format=ImportanceDirectoryFormat)
+plugin.register_semantic_type_to_format(
     SampleData[Probabilities],
     artifact_format=ProbabilitiesDirectoryFormat)
 plugin.register_semantic_type_to_format(
@@ -669,7 +674,8 @@ plugin.register_semantic_type_to_format(
     artifact_format=TrueTargetsDirectoryFormat)
 plugin.register_formats(
     SampleEstimatorDirFmt, BooleanSeriesFormat, BooleanSeriesDirectoryFormat,
-    PredictionsFormat, PredictionsDirectoryFormat, ProbabilitiesFormat,
+    ImportanceFormat, ImportanceDirectoryFormat, PredictionsFormat,
+    PredictionsDirectoryFormat, ProbabilitiesFormat,
     ProbabilitiesDirectoryFormat,
     TrueTargetsDirectoryFormat)
 importlib.import_module('q2_sample_classifier._transformer')

--- a/q2_sample_classifier/tests/test_types_formats_transformers.py
+++ b/q2_sample_classifier/tests/test_types_formats_transformers.py
@@ -18,13 +18,15 @@ from sklearn.pipeline import Pipeline
 
 
 import qiime2
+from q2_types.feature_data import FeatureData
 from qiime2.plugin import ValidationError
 from q2_types.sample_data import SampleData
 
 from q2_sample_classifier import (
     BooleanSeriesFormat, BooleanSeriesDirectoryFormat, BooleanSeries,
     PredictionsFormat, PredictionsDirectoryFormat, ClassifierPredictions,
-    RegressorPredictions, PickleFormat, ProbabilitiesFormat,
+    RegressorPredictions, ImportanceFormat, ImportanceDirectoryFormat,
+    Importance, PickleFormat, ProbabilitiesFormat,
     ProbabilitiesDirectoryFormat, Probabilities, Classifier, Regressor,
     SampleEstimator, SampleEstimatorDirFmt,
     TrueTargetsDirectoryFormat, TrueTargets)
@@ -179,6 +181,80 @@ class TestSemanticTypes(SampleClassifierTestPluginBase):
                               '10249.C004.01SS', '10249.C004.11SS'],
                              name='id')
         exp = pd.DataFrame([4.5, 2.5, 0.5, 4.5], columns=['prediction'],
+                           index=exp_index)
+        pdt.assert_frame_equal(obs.to_dataframe()[:4], exp)
+
+    # test Importance format
+    def test_Importance_format_validate_positive(self):
+        filepath = self.get_data_path('importance.tsv')
+        format = ImportanceFormat(filepath, mode='r')
+        format.validate(level='min')
+        format.validate()
+
+    def test_Importance_format_validate_negative_nonnumeric(self):
+        filepath = self.get_data_path('chardonnay.map.txt')
+        format = ImportanceFormat(filepath, mode='r')
+        with self.assertRaisesRegex(ValidationError, 'numeric values'):
+            format.validate()
+
+    def test_Importance_format_validate_negative_empty(self):
+        filepath = self.get_data_path('empty_file.txt')
+        format = ImportanceFormat(filepath, mode='r')
+        with self.assertRaisesRegex(ValidationError, 'one data record'):
+            format.validate()
+
+    def test_Importance_format_validate_negative(self):
+        filepath = self.get_data_path('garbage.txt')
+        format = ImportanceFormat(filepath, mode='r')
+        with self.assertRaisesRegex(ValidationError, 'two or more fields'):
+            format.validate()
+
+    def test_Importance_dir_fmt_validate_positive(self):
+        filepath = self.get_data_path('importance.tsv')
+        shutil.copy(filepath, self.temp_dir.name)
+        format = ImportanceDirectoryFormat(self.temp_dir.name, mode='r')
+        format.validate()
+
+    def test_Importance_semantic_type_registration(self):
+        self.assertRegisteredSemanticType(Importance)
+
+    def test_sample_data_Importance_to_Importance_dir_fmt_registration(self):
+        self.assertSemanticTypeRegisteredToFormat(
+            FeatureData[Importance], ImportanceDirectoryFormat)
+
+    def test_pd_dataframe_to_Importance_format(self):
+        transformer = self.get_transformer(pd.DataFrame, ImportanceFormat)
+        exp = pd.DataFrame([1, 2, 3, 4],
+                           columns=['importance'], index=['a', 'b', 'c', 'd'])
+        obs = transformer(exp)
+        obs = pd.read_csv(str(obs), sep='\t', header=0, index_col=0)
+        pdt.assert_frame_equal(exp, obs)
+
+    def test_Importance_format_to_pd_dataframe(self):
+        _, obs = self.transform_format(
+            ImportanceFormat, pd.DataFrame, 'importance.tsv')
+        exp_index = pd.Index(['74ec9fe6ffab4ecff6d5def74298a825',
+                              'c82032c40c98975f71892e4be561c87a',
+                              '79280cea51a6fe8a3432b2f266dd34db',
+                              'f7686a74ca2d3729eb66305e8a26309b'],
+                             name='id')
+        exp = pd.DataFrame([0.44469828320835586, 0.07760118417569697,
+                            0.06570251750505914, 0.061718558716901406],
+                           columns=['importance'],
+                           index=exp_index)
+        pdt.assert_frame_equal(exp, obs[:4])
+
+    def test_Importance_format_to_metadata(self):
+        _, obs = self.transform_format(
+            ImportanceFormat, qiime2.Metadata, 'importance.tsv')
+        exp_index = pd.Index(['74ec9fe6ffab4ecff6d5def74298a825',
+                              'c82032c40c98975f71892e4be561c87a',
+                              '79280cea51a6fe8a3432b2f266dd34db',
+                              'f7686a74ca2d3729eb66305e8a26309b'],
+                             name='id')
+        exp = pd.DataFrame([0.44469828320835586, 0.07760118417569697,
+                            0.06570251750505914, 0.061718558716901406],
+                           columns=['importance'],
                            index=exp_index)
         pdt.assert_frame_equal(obs.to_dataframe()[:4], exp)
 


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
This reverts commit 681ee8a37ed91874de2a500ee43cdc73c820a4da.
TESTING: new `Paired-*` PR branch behavior. Reverting changes from the latest types migration since this is the exact use-case that this new behavior covers.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
